### PR TITLE
Switch dashboard layout to CSS Grid

### DIFF
--- a/moo-app/src/pages/Dashboard.tsx
+++ b/moo-app/src/pages/Dashboard.tsx
@@ -1,14 +1,13 @@
 import React, { PropsWithChildren } from "react";
 
 import { Page, PageProps } from "../layout/Page";
-import { Row } from "@andrewmclachlan/moo-ds";
 import classNames from "classnames";
 
 export const Dashboard: React.FC<PropsWithChildren<DashboardProps>> = ({className, children, ...rest}) => (
     <Page className={classNames("dashboard", className)} {...rest}>
-        <Row>
+        <div className="dashboard-grid">
             {children}
-        </Row>
+        </div>
     </Page>
 );
 

--- a/moo-ds/src/components/Widget.tsx
+++ b/moo-ds/src/components/Widget.tsx
@@ -1,15 +1,14 @@
 import { Section } from "../layout/Section/Section";
 import { PropsWithChildren } from "react";
-import { Col } from "./Col";
 import { SpinnerContainer } from "./SpinnerContainer";
 
 export const Widget: React.FC<PropsWithChildren<WidgetProps>> = ({ children, loading = false, size = "single", ...rest }) => (
-    <Col xxl={4} xl={6} lg={12} className={size}>
+    <div className={size}>
         <Section {...rest}>
             {loading && <SpinnerContainer />}
             {!loading && children}
         </Section>
-    </Col>
+    </div>
 )
 
 Widget.displayName = "Widget";

--- a/moo-ds/src/components/__tests__/Widget.test.tsx
+++ b/moo-ds/src/components/__tests__/Widget.test.tsx
@@ -69,18 +69,19 @@ describe('Widget', () => {
   });
 
   describe('layout', () => {
-    it('renders in a Col container', () => {
+    it('renders in a div container with size class', () => {
       const { container } = render(<Widget size="single">Content</Widget>);
 
-      // Bootstrap Col renders with responsive classes like col-xxl-4
-      expect(container.querySelector('[class*="col-"]')).toBeInTheDocument();
+      const wrapper = container.firstElementChild;
+      expect(wrapper?.tagName).toBe('DIV');
+      expect(wrapper).toHaveClass('single');
     });
 
-    it('applies responsive column classes', () => {
-      const { container } = render(<Widget size="single">Content</Widget>);
+    it('renders double size in a div with double class', () => {
+      const { container } = render(<Widget size="double">Content</Widget>);
 
-      const col = container.querySelector('[class*="col-xxl"]');
-      expect(col).toBeInTheDocument();
+      const wrapper = container.firstElementChild;
+      expect(wrapper).toHaveClass('double');
     });
   });
 

--- a/moo-ds/src/css/colours.css
+++ b/moo-ds/src/css/colours.css
@@ -1,11 +1,19 @@
-.danger {
+.danger, .text-danger {
     color: var(--danger);
 }
 
-.warning {
+.warning, .text-warning {
     color: var(--warning);
 }
 
-.success {
+.success, .text-success {
     color: var(--success);
+}
+
+.text-muted {
+    color: var(--secondary-color);
+}
+
+.text-primary {
+    color: var(--primary);
 }

--- a/moo-ds/src/css/components/_forms.css
+++ b/moo-ds/src/css/components/_forms.css
@@ -38,13 +38,13 @@ input.form-control {
     padding: var(--input-padding-v) var(--input-padding-h);
 
     &:read-only {
-        background-color: var(--disabled-bg, #e9ecef);
+        background-color: transparent;
         cursor: default;
 
         &:focus {
             box-shadow: none;
             border-color: var(--border-color, #dee2e6);
-            background-color: var(--disabled-bg, #e9ecef);
+            background-color: transparent;
         }
     }
 }

--- a/moo-ds/src/css/pages/_dashboard.css
+++ b/moo-ds/src/css/pages/_dashboard.css
@@ -1,22 +1,41 @@
 main.dashboard {
-    .row {
-        --gutter-y: 1.5rem;
+    .dashboard-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        grid-auto-rows: 300px;
+        grid-auto-flow: dense;
+        gap: 1.5rem;
 
         > div {
-
-            &.single {
-                max-height: 300px;
-            }
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
 
             &.double {
-                max-height: calc(600px + 1.5rem);
+                grid-row: span 2;
             }
+        }
+
+        @media (max-width: 1399.98px) {
+            grid-template-columns: repeat(2, 1fr);
+        }
+
+        @media (max-width: 991.98px) {
+            grid-template-columns: 1fr;
         }
     }
 
     .section {
-        flex: 0 0 auto;
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
 
-        height: 100%;
+        > *:not(.section-header) {
+            flex: 1;
+            min-height: 0;
+            overflow: hidden;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Replace Bootstrap flexbox `Row`/`Col` with CSS Grid for the dashboard widget layout
- Enables double-height widgets to flow correctly with `grid-auto-flow: dense`, preventing gaps when wrapping to fewer columns
- Widget renders a plain `div` instead of `Col` — grid handles column sizing
- Fix section height chain using flex column layout so Chart.js containers get proper dimensions
- Add `text-danger`, `text-success`, `text-warning`, `text-muted`, `text-primary` colour classes
- Make readonly input background transparent

## Test plan
- [x] All 1096 moo-ds tests pass
- [x] All 319 moo-app tests pass
- [x] Visual check: 3-column dashboard at xxl, 2-column at xl, 1-column at lg
- [x] Visual check: double-height widgets (Breakdown, Top Tags) fill correctly without gaps
- [x] Visual check: Chart.js widgets render within container bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)