### PR TITLE
Badge: add muted/outline variants, hue palette, and custom colour

### DIFF
--- a/demoo/src/index.tsx
+++ b/demoo/src/index.tsx
@@ -1,6 +1,6 @@
 import { MooApp, NotFound } from "@andrewmclachlan/moo-app";
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faArrowLeft, faArrowsRotate, faCheck, faCheckCircle, faChevronDown, faChevronRight, faChevronUp, faCircleChevronLeft, faFilterCircleXmark, faInfoCircle, faLongArrowDown, faLongArrowUp, faPenToSquare, faPlus, faTimesCircle, faTrashAlt, faUpload, faXmark } from "@fortawesome/free-solid-svg-icons";
+import { faArrowLeft, faArrowsRotate, faBolt, faCheck, faCheckCircle, faChevronDown, faChevronRight, faChevronUp, faCircleChevronLeft, faCircleInfo, faCircleXmark, faFilterCircleXmark, faHeart, faInfoCircle, faLeaf, faLongArrowDown, faLongArrowUp, faPenToSquare, faPlus, faStar, faTimesCircle, faTrashAlt, faTriangleExclamation, faUpload, faXmark } from "@fortawesome/free-solid-svg-icons";
 import { createRootRoute, createRoute, createRouter } from "@tanstack/react-router";
 import ReactDOM from "react-dom/client";
 import App from "./App";
@@ -29,7 +29,7 @@ const root = ReactDOM.createRoot(
 console.debug((import.meta as any).env);
 console.debug((import.meta as any).env.VITE_REACT_APP_VERSION);
 
-library.add(faArrowsRotate, faCheck, faCheckCircle, faTrashAlt, faChevronDown, faChevronUp, faTimesCircle, faArrowLeft, faLongArrowUp, faLongArrowDown, faChevronRight, faCircleChevronLeft, faUpload, faXmark, faFilterCircleXmark, faInfoCircle, faPenToSquare, faPlus);
+library.add(faArrowsRotate, faCheck, faCheckCircle, faTrashAlt, faChevronDown, faChevronUp, faTimesCircle, faArrowLeft, faLongArrowUp, faLongArrowDown, faChevronRight, faCircleChevronLeft, faUpload, faXmark, faFilterCircleXmark, faInfoCircle, faPenToSquare, faPlus, faStar, faTriangleExclamation, faBolt, faLeaf, faHeart, faCircleInfo, faCircleXmark);
 
 const rootRoute = createRootRoute({
   component: App,

--- a/demoo/src/routes/Components.tsx
+++ b/demoo/src/routes/Components.tsx
@@ -2,6 +2,7 @@ import { Page } from "@andrewmclachlan/moo-app";
 import { Section, NavItemDivider, IconButton, SectionTable, EditColumn, ComboBox, Button, Modal, ButtonGroup, Badge, CloseBadge, Alert, Nav, Tabs, Tab, Collapsible } from "@andrewmclachlan/moo-ds";
 import { Tags } from "@andrewmclachlan/moo-icons";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useState } from "react";
 
 export const Components = () => {
@@ -51,19 +52,95 @@ export const Components = () => {
             </Section>
 
             <Section title="Badges" header="Badges" headerSize={4}>
+                <h5>Semantic — solid</h5>
                 <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap", marginBottom: "1rem" }}>
                     <Badge bg="primary">Primary</Badge>
+                    <Badge bg="secondary">Secondary</Badge>
                     <Badge bg="success">Success</Badge>
                     <Badge bg="danger">Danger</Badge>
                     <Badge bg="warning">Warning</Badge>
                     <Badge bg="info">Info</Badge>
                 </div>
+                <h5>Hues — solid</h5>
+                <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap", marginBottom: "1rem" }}>
+                    <Badge bg="blue">Blue</Badge>
+                    <Badge bg="indigo">Indigo</Badge>
+                    <Badge bg="purple">Purple</Badge>
+                    <Badge bg="pink">Pink</Badge>
+                    <Badge bg="rose">Rose</Badge>
+                    <Badge bg="orange">Orange</Badge>
+                    <Badge bg="amber">Amber</Badge>
+                    <Badge bg="yellow">Yellow</Badge>
+                    <Badge bg="green">Green</Badge>
+                    <Badge bg="emerald">Emerald</Badge>
+                    <Badge bg="teal">Teal</Badge>
+                    <Badge bg="cyan">Cyan</Badge>
+                    <Badge bg="slate">Slate</Badge>
+                    <Badge bg="neutral">Neutral</Badge>
+                </div>
+                <h5>Hues — muted</h5>
+                <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap", marginBottom: "1rem" }}>
+                    <Badge bg="blue" muted>Blue</Badge>
+                    <Badge bg="indigo" muted>Indigo</Badge>
+                    <Badge bg="purple" muted>Purple</Badge>
+                    <Badge bg="pink" muted>Pink</Badge>
+                    <Badge bg="rose" muted>Rose</Badge>
+                    <Badge bg="orange" muted>Orange</Badge>
+                    <Badge bg="amber" muted>Amber</Badge>
+                    <Badge bg="yellow" muted>Yellow</Badge>
+                    <Badge bg="green" muted>Green</Badge>
+                    <Badge bg="emerald" muted>Emerald</Badge>
+                    <Badge bg="teal" muted>Teal</Badge>
+                    <Badge bg="cyan" muted>Cyan</Badge>
+                    <Badge bg="slate" muted>Slate</Badge>
+                    <Badge bg="neutral" muted>Neutral</Badge>
+                </div>
+                <h5>Hues — outline</h5>
+                <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap", marginBottom: "1rem" }}>
+                    <Badge bg="blue" outline>Blue</Badge>
+                    <Badge bg="indigo" outline>Indigo</Badge>
+                    <Badge bg="purple" outline>Purple</Badge>
+                    <Badge bg="pink" outline>Pink</Badge>
+                    <Badge bg="rose" outline>Rose</Badge>
+                    <Badge bg="orange" outline>Orange</Badge>
+                    <Badge bg="amber" outline>Amber</Badge>
+                    <Badge bg="yellow" outline>Yellow</Badge>
+                    <Badge bg="green" outline>Green</Badge>
+                    <Badge bg="emerald" outline>Emerald</Badge>
+                    <Badge bg="teal" outline>Teal</Badge>
+                    <Badge bg="cyan" outline>Cyan</Badge>
+                    <Badge bg="slate" outline>Slate</Badge>
+                    <Badge bg="neutral" outline>Neutral</Badge>
+                </div>
+                <h5>Pills</h5>
+                <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap", marginBottom: "1rem" }}>
+                    <Badge bg="primary" pill>Primary</Badge>
+                    <Badge bg="indigo" pill muted>Indigo muted</Badge>
+                    <Badge bg="teal" pill outline>Teal outline</Badge>
+                    <Badge bg="rose" pill>Rose</Badge>
+                </div>
+                <h5>Custom colour</h5>
+                <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap", marginBottom: "1rem" }}>
+                    <Badge colour="#7c6cff">Hex</Badge>
+                    <Badge colour="rgb(255, 99, 132)">RGB</Badge>
+                    <Badge colour="hsl(160, 70%, 45%)">HSL</Badge>
+                    <Badge colour="var(--primary)">CSS var</Badge>
+                    <Badge colour="#fde68a" textColour="#78350f">Light bg / dark text</Badge>
+                    <Badge colour="#7c6cff" muted>Custom muted</Badge>
+                    <Badge colour="#7c6cff" outline>Custom outline</Badge>
+                </div>
+                <h5>With icon</h5>
+                <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap", marginBottom: "1rem" }}>
+                    <Badge bg="primary" icon={<FontAwesomeIcon icon="star" />}>Featured</Badge>
+                    <Badge bg="success" icon={<FontAwesomeIcon icon="check" />}>Done</Badge>
+                    <Badge bg="danger" icon={<FontAwesomeIcon icon="circle-xmark" />}>Failed</Badge>
+                    <Badge bg="warning" icon={<FontAwesomeIcon icon="triangle-exclamation" />}>Warning</Badge>
+                </div>
                 <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
-                    <Badge bg="primary" pill>Primary Pill</Badge>
-                    <Badge bg="success" pill>Success Pill</Badge>
-                    <Badge bg="danger" pill>Danger Pill</Badge>
-                    <Badge bg="warning" pill>Warning Pill</Badge>
-                    <Badge bg="info" pill>Info Pill</Badge>
+                    <Badge bg="indigo" muted icon={<FontAwesomeIcon icon="bolt" />}>Muted</Badge>
+                    <Badge bg="teal" outline icon={<FontAwesomeIcon icon="leaf" />}>Outline</Badge>
+                    <Badge bg="rose" pill icon={<FontAwesomeIcon icon="heart" />}>Pill</Badge>
+                    <Badge colour="#7c6cff" muted icon={<FontAwesomeIcon icon="bolt" />}>Custom + muted</Badge>
                 </div>
             </Section>
 

--- a/moo-ds/src/components/Badge.tsx
+++ b/moo-ds/src/components/Badge.tsx
@@ -39,13 +39,16 @@ export const Badge = React.forwardRef<HTMLSpanElement, React.PropsWithChildren<B
     ({ bg = "primary", colour, textColour, muted, outline, pill, icon, className, children, style, ...rest }, ref) => {
         const useCustom = !!colour;
 
-        const inlineStyle: BadgeCssVars | undefined = useCustom
-            ? {
-                ...style,
-                "--badge-bg": colour,
-                ...(textColour ? { "--badge-fg": textColour } : {}),
+        let inlineStyle: BadgeCssVars | undefined = style;
+        if (useCustom) {
+            inlineStyle = { ...style, "--badge-bg": colour };
+            if (textColour) {
+                inlineStyle["--badge-fg"] = textColour;
+                // Muted and outline compute color via color-mix and don't read --badge-fg.
+                // Set color directly so an explicit textColour wins in those variants too.
+                inlineStyle.color = textColour;
             }
-            : style;
+        }
 
         const classes = classNames(
             "badge",

--- a/moo-ds/src/components/Badge.tsx
+++ b/moo-ds/src/components/Badge.tsx
@@ -1,22 +1,66 @@
 import classNames from "classnames";
 import React from "react";
 
+export type BadgeSemantic = "primary" | "secondary" | "success" | "danger" | "warning" | "info";
+
+export type BadgeHue =
+    | "blue" | "indigo" | "purple" | "pink" | "rose"
+    | "orange" | "amber" | "yellow"
+    | "green" | "emerald" | "teal" | "cyan"
+    | "slate" | "neutral";
+
 export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
-    bg?: string;
+    /**
+     * Named token: a semantic variant or a hue. Ignored when `colour` is also supplied.
+     */
+    bg?: BadgeSemantic | BadgeHue;
+    /**
+     * Any CSS colour value. Overrides `bg` when provided.
+     * Examples: "#7c6cff", "rgb(124,108,255)", "var(--brand-teal)".
+     */
+    colour?: string;
+    /**
+     * Optional foreground colour, used together with `colour` when the default doesn't suit
+     * (e.g. light custom colours that need dark text). Ignored when `bg` is used alone.
+     */
+    textColour?: string;
+    muted?: boolean;
+    outline?: boolean;
     pill?: boolean;
+    icon?: React.ReactNode;
 }
 
+type BadgeCssVars = React.CSSProperties & {
+    "--badge-bg"?: string;
+    "--badge-fg"?: string;
+};
+
 export const Badge = React.forwardRef<HTMLSpanElement, React.PropsWithChildren<BadgeProps>>(
-    ({ bg = "primary", pill, className, children, ...rest }, ref) => {
+    ({ bg = "primary", colour, textColour, muted, outline, pill, icon, className, children, style, ...rest }, ref) => {
+        const useCustom = !!colour;
+
+        const inlineStyle: BadgeCssVars | undefined = useCustom
+            ? {
+                ...style,
+                "--badge-bg": colour,
+                ...(textColour ? { "--badge-fg": textColour } : {}),
+            }
+            : style;
+
         const classes = classNames(
             "badge",
-            bg && `bg-${bg}`,
+            !useCustom && bg && `bg-${bg}`,
+            // outline wins when both supplied
+            outline && "badge-outline",
+            muted && !outline && "badge-muted",
             pill && "rounded-pill",
+            icon && "badge-with-icon",
             className,
         );
 
         return (
-            <span ref={ref} className={classes} {...rest}>
+            <span ref={ref} className={classes} style={inlineStyle} {...rest}>
+                {icon}
                 {children}
             </span>
         );

--- a/moo-ds/src/components/__tests__/Badge.test.tsx
+++ b/moo-ds/src/components/__tests__/Badge.test.tsx
@@ -119,6 +119,18 @@ describe('Badge', () => {
       expect(badge.style.marginLeft).toBe('8px');
       expect(badge.style.getPropertyValue('--badge-bg')).toBe('#abcdef');
     });
+
+    it('also applies inline color so textColour wins over muted/outline', () => {
+      render(<Badge colour="#abcdef" textColour="#123456" muted>Muted</Badge>);
+      const badge = screen.getByText('Muted');
+      expect(badge.style.color).toBe('rgb(18, 52, 86)');
+    });
+
+    it('does not set inline color when textColour is not supplied', () => {
+      render(<Badge colour="#abcdef">Just colour</Badge>);
+      const badge = screen.getByText('Just colour');
+      expect(badge.style.color).toBe('');
+    });
   });
 
   describe('icon', () => {

--- a/moo-ds/src/components/__tests__/Badge.test.tsx
+++ b/moo-ds/src/components/__tests__/Badge.test.tsx
@@ -46,4 +46,98 @@ describe('Badge', () => {
   it('has displayName', () => {
     expect(Badge.displayName).toBe('Badge');
   });
+
+  describe('muted', () => {
+    it('applies badge-muted when muted is true', () => {
+      render(<Badge muted>Muted</Badge>);
+      expect(screen.getByText('Muted')).toHaveClass('badge-muted');
+    });
+
+    it('does not apply badge-muted by default', () => {
+      render(<Badge>Plain</Badge>);
+      expect(screen.getByText('Plain')).not.toHaveClass('badge-muted');
+    });
+  });
+
+  describe('outline', () => {
+    it('applies badge-outline when outline is true', () => {
+      render(<Badge outline>Outline</Badge>);
+      expect(screen.getByText('Outline')).toHaveClass('badge-outline');
+    });
+
+    it('outline wins when both muted and outline are passed', () => {
+      render(<Badge muted outline>Both</Badge>);
+      const badge = screen.getByText('Both');
+      expect(badge).toHaveClass('badge-outline');
+      expect(badge).not.toHaveClass('badge-muted');
+    });
+  });
+
+  describe('hue tokens', () => {
+    const hues = [
+      'blue', 'indigo', 'purple', 'pink', 'rose',
+      'orange', 'amber', 'yellow',
+      'green', 'emerald', 'teal', 'cyan',
+      'slate', 'neutral',
+    ] as const;
+
+    it.each(hues)('applies bg-%s for the %s hue', (hue) => {
+      render(<Badge bg={hue}>{hue}</Badge>);
+      expect(screen.getByText(hue)).toHaveClass(`bg-${hue}`);
+    });
+  });
+
+  describe('custom colour', () => {
+    it('sets --badge-bg inline when colour is provided', () => {
+      render(<Badge colour="#7c6cff">Custom</Badge>);
+      const badge = screen.getByText('Custom');
+      expect(badge.style.getPropertyValue('--badge-bg')).toBe('#7c6cff');
+    });
+
+    it('does not apply a bg-* class when colour is provided', () => {
+      render(<Badge bg="success" colour="#7c6cff">Custom</Badge>);
+      const badge = screen.getByText('Custom');
+      expect(badge).not.toHaveClass('bg-success');
+      expect(badge).not.toHaveClass('bg-primary');
+    });
+
+    it('sets --badge-fg inline when textColour is provided with colour', () => {
+      render(<Badge colour="#ffffff" textColour="#000000">Custom</Badge>);
+      const badge = screen.getByText('Custom');
+      expect(badge.style.getPropertyValue('--badge-fg')).toBe('#000000');
+    });
+
+    it('does not set --badge-fg when only textColour is provided', () => {
+      render(<Badge textColour="#000">No colour</Badge>);
+      const badge = screen.getByText('No colour');
+      expect(badge.style.getPropertyValue('--badge-fg')).toBe('');
+    });
+
+    it('preserves caller-supplied style alongside colour', () => {
+      render(<Badge colour="#abcdef" style={{ marginLeft: 8 }}>Styled</Badge>);
+      const badge = screen.getByText('Styled');
+      expect(badge.style.marginLeft).toBe('8px');
+      expect(badge.style.getPropertyValue('--badge-bg')).toBe('#abcdef');
+    });
+  });
+
+  describe('icon', () => {
+    it('renders the icon node before children', () => {
+      const { container } = render(
+        <Badge icon={<svg data-testid="ic" />}>Label</Badge>
+      );
+      const badge = container.querySelector('.badge')!;
+      expect(badge.firstChild).toBe(container.querySelector('[data-testid="ic"]'));
+    });
+
+    it('applies badge-with-icon class when icon present', () => {
+      render(<Badge icon={<svg />}>Label</Badge>);
+      expect(screen.getByText('Label')).toHaveClass('badge-with-icon');
+    });
+
+    it('omits badge-with-icon class when no icon', () => {
+      render(<Badge>Label</Badge>);
+      expect(screen.getByText('Label')).not.toHaveClass('badge-with-icon');
+    });
+  });
 });

--- a/moo-ds/src/components/comboBox/ComboBoxSelectedItem.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxSelectedItem.tsx
@@ -16,11 +16,9 @@ export const ComboBoxSelectedItem = <T,>({item}: ComboBoxSelectedItemProps<T>) =
     if (item === undefined) return null;
 
     const bgColour = colourField?.(item);
-    const bg = bgColour ? "none" : "primary";
-
 
     return (
-        <div className="item"><CloseBadge pill bg={bg} style={{backgroundColor: bgColour}} onClose={() => removeItem(item)}>{labelField(item)}</CloseBadge></div>
+        <div className="item"><CloseBadge pill bg="primary" colour={bgColour} onClose={() => removeItem(item)}>{labelField(item)}</CloseBadge></div>
     );
 }
 

--- a/moo-ds/src/components/comboBox/__tests__/ComboBoxSelectedItem.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBoxSelectedItem.test.tsx
@@ -78,8 +78,10 @@ describe('ComboBoxSelectedItem', () => {
         { colourField: (item: Item) => item.color }
       );
 
-      const badge = container.querySelector('.badge');
-      expect(badge).toHaveStyle({ backgroundColor: '#ff0000' });
+      const badge = container.querySelector<HTMLElement>('.badge')!;
+      expect(badge.style.getPropertyValue('--badge-bg')).toBe('#ff0000');
+      // bg-* class is suppressed when a custom colour is supplied
+      expect(badge).not.toHaveClass('bg-primary');
     });
   });
 

--- a/moo-ds/src/css/_variables.css
+++ b/moo-ds/src/css/_variables.css
@@ -20,6 +20,22 @@
   --warning: var(--amber);
   --success: var(--green);
 
+  /* Hue palette - dark-mode-first defaults; overridden under .light / [data-theme="light"]. */
+  --hue-blue:    #4d8bff;
+  --hue-indigo:  #7c6cff;
+  --hue-purple:  #a070ff;
+  --hue-pink:    #ec4899;
+  --hue-rose:    #f06292;
+  --hue-orange:  #ff8a4c;
+  --hue-amber:   #f5c451;
+  --hue-yellow:  #facc15;
+  --hue-green:   #22c55e;
+  --hue-emerald: #25c281;
+  --hue-teal:    #2bc4d4;
+  --hue-cyan:    #22d3ee;
+  --hue-slate:   #b0bccb;
+  --hue-neutral: #bac3cf;
+
   --table-bg: var(--body-bg);
 
   --toastify-color-progress-light: var(--primary);
@@ -85,6 +101,22 @@
 .light,
 [data-theme="light"] {
   color-scheme: light;
+
+  /* Hue palette - darker, more saturated for legibility on light surfaces. */
+  --hue-blue:    #2563eb;
+  --hue-indigo:  #4f46e5;
+  --hue-purple:  #7c3aed;
+  --hue-pink:    #db2777;
+  --hue-rose:    #e11d48;
+  --hue-orange:  #ea580c;
+  --hue-amber:   #d97706;
+  --hue-yellow:  #ca8a04;
+  --hue-green:   #16a34a;
+  --hue-emerald: #059669;
+  --hue-teal:    #0891b2;
+  --hue-cyan:    #0e7490;
+  --hue-slate:   #475569;
+  --hue-neutral: #64748b;
 }
 
 /* Force dark mode */

--- a/moo-ds/src/css/_variables.css
+++ b/moo-ds/src/css/_variables.css
@@ -20,21 +20,22 @@
   --warning: var(--amber);
   --success: var(--green);
 
-  /* Hue palette - dark-mode-first defaults; overridden under .light / [data-theme="light"]. */
-  --hue-blue:    #4d8bff;
-  --hue-indigo:  #7c6cff;
-  --hue-purple:  #a070ff;
-  --hue-pink:    #ec4899;
-  --hue-rose:    #f06292;
-  --hue-orange:  #ff8a4c;
-  --hue-amber:   #f5c451;
-  --hue-yellow:  #facc15;
-  --hue-green:   #22c55e;
-  --hue-emerald: #25c281;
-  --hue-teal:    #2bc4d4;
-  --hue-cyan:    #22d3ee;
-  --hue-slate:   #b0bccb;
-  --hue-neutral: #bac3cf;
+  /* Hue palette - resolves via color-scheme. Light values are darker/saturated
+     for legibility on white; dark values are brighter for dark surfaces. */
+  --hue-blue:    light-dark(#2563eb, #4d8bff);
+  --hue-indigo:  light-dark(#4f46e5, #7c6cff);
+  --hue-purple:  light-dark(#7c3aed, #a070ff);
+  --hue-pink:    light-dark(#db2777, #ec4899);
+  --hue-rose:    light-dark(#e11d48, #f06292);
+  --hue-orange:  light-dark(#ea580c, #ff8a4c);
+  --hue-amber:   light-dark(#d97706, #f5c451);
+  --hue-yellow:  light-dark(#ca8a04, #facc15);
+  --hue-green:   light-dark(#16a34a, #22c55e);
+  --hue-emerald: light-dark(#059669, #25c281);
+  --hue-teal:    light-dark(#0891b2, #2bc4d4);
+  --hue-cyan:    light-dark(#0e7490, #22d3ee);
+  --hue-slate:   light-dark(#475569, #b0bccb);
+  --hue-neutral: light-dark(#64748b, #bac3cf);
 
   --table-bg: var(--body-bg);
 
@@ -101,22 +102,6 @@
 .light,
 [data-theme="light"] {
   color-scheme: light;
-
-  /* Hue palette - darker, more saturated for legibility on light surfaces. */
-  --hue-blue:    #2563eb;
-  --hue-indigo:  #4f46e5;
-  --hue-purple:  #7c3aed;
-  --hue-pink:    #db2777;
-  --hue-rose:    #e11d48;
-  --hue-orange:  #ea580c;
-  --hue-amber:   #d97706;
-  --hue-yellow:  #ca8a04;
-  --hue-green:   #16a34a;
-  --hue-emerald: #059669;
-  --hue-teal:    #0891b2;
-  --hue-cyan:    #0e7490;
-  --hue-slate:   #475569;
-  --hue-neutral: #64748b;
 }
 
 /* Force dark mode */

--- a/moo-ds/src/css/components/_badge.css
+++ b/moo-ds/src/css/components/_badge.css
@@ -14,10 +14,9 @@
     padding: var(--badge-padding-y) var(--badge-padding-x);
     font-size: var(--badge-font-size);
     font-weight: var(--badge-font-weight);
-    line-height: 1.3;
+    line-height: 1;
     color: var(--badge-fg);
     background: var(--badge-bg);
-    border: 1px solid transparent;
     text-align: center;
     white-space: nowrap;
     vertical-align: baseline;
@@ -48,14 +47,13 @@
 .badge.badge-muted {
     background: color-mix(in srgb, var(--badge-bg) 22%, #000);
     color: color-mix(in srgb, var(--badge-bg) 45%, #fff);
-    border-color: transparent;
 }
 
-/* Outline: transparent background, hue border + text */
+/* Outline: transparent background, hue ring (via inset shadow to avoid layout shift) + hue text */
 .badge.badge-outline {
     background: transparent;
     color: color-mix(in srgb, var(--badge-bg) 45%, #fff);
-    border-color: var(--badge-bg);
+    box-shadow: inset 0 0 0 1px var(--badge-bg);
 }
 
 /* Light-mode muted/outline overrides - more contrast against white surfaces */
@@ -101,52 +99,19 @@
 .bg-info      { --badge-bg: #0dcaf0;        --badge-fg: #000; }
 
 /* ---- Hue tokens ----
-   Default (dark-mode) foregrounds. Light-mode block below switches the
-   darker light-mode hues to white text for contrast. */
+   Foreground uses light-dark() so it tracks the hue palette in _variables.css.
+   First arg = light mode, second = dark mode. */
 .bg-blue    { --badge-bg: var(--hue-blue);    --badge-fg: #fff; }
 .bg-indigo  { --badge-bg: var(--hue-indigo);  --badge-fg: #fff; }
 .bg-purple  { --badge-bg: var(--hue-purple);  --badge-fg: #fff; }
 .bg-pink    { --badge-bg: var(--hue-pink);    --badge-fg: #fff; }
 .bg-rose    { --badge-bg: var(--hue-rose);    --badge-fg: #fff; }
-.bg-orange  { --badge-bg: var(--hue-orange);  --badge-fg: #1a0f00; }
-.bg-amber   { --badge-bg: var(--hue-amber);   --badge-fg: #1a1300; }
-.bg-yellow  { --badge-bg: var(--hue-yellow);  --badge-fg: #1a1700; }
-.bg-green   { --badge-bg: var(--hue-green);   --badge-fg: #001a0e; }
-.bg-emerald { --badge-bg: var(--hue-emerald); --badge-fg: #001a0e; }
-.bg-teal    { --badge-bg: var(--hue-teal);    --badge-fg: #001a1f; }
-.bg-cyan    { --badge-bg: var(--hue-cyan);    --badge-fg: #001a1f; }
-.bg-slate   { --badge-bg: var(--hue-slate);   --badge-fg: #0a0f15; }
-.bg-neutral { --badge-bg: var(--hue-neutral); --badge-fg: #0a0f15; }
-
-/* Light-mode hue foregrounds - the darker hues need white text for contrast. */
-@media (prefers-color-scheme: light) {
-    .bg-orange,
-    .bg-amber,
-    .bg-yellow,
-    .bg-green,
-    .bg-emerald,
-    .bg-teal,
-    .bg-cyan,
-    .bg-slate,
-    .bg-neutral { --badge-fg: #fff; }
-}
-
-.light .bg-orange,    [data-theme="light"] .bg-orange,
-.light .bg-amber,     [data-theme="light"] .bg-amber,
-.light .bg-yellow,    [data-theme="light"] .bg-yellow,
-.light .bg-green,     [data-theme="light"] .bg-green,
-.light .bg-emerald,   [data-theme="light"] .bg-emerald,
-.light .bg-teal,      [data-theme="light"] .bg-teal,
-.light .bg-cyan,      [data-theme="light"] .bg-cyan,
-.light .bg-slate,     [data-theme="light"] .bg-slate,
-.light .bg-neutral,   [data-theme="light"] .bg-neutral { --badge-fg: #fff; }
-
-.dark .bg-orange,    [data-theme="dark"] .bg-orange    { --badge-fg: #1a0f00; }
-.dark .bg-amber,     [data-theme="dark"] .bg-amber     { --badge-fg: #1a1300; }
-.dark .bg-yellow,    [data-theme="dark"] .bg-yellow    { --badge-fg: #1a1700; }
-.dark .bg-green,     [data-theme="dark"] .bg-green     { --badge-fg: #001a0e; }
-.dark .bg-emerald,   [data-theme="dark"] .bg-emerald   { --badge-fg: #001a0e; }
-.dark .bg-teal,      [data-theme="dark"] .bg-teal      { --badge-fg: #001a1f; }
-.dark .bg-cyan,      [data-theme="dark"] .bg-cyan      { --badge-fg: #001a1f; }
-.dark .bg-slate,     [data-theme="dark"] .bg-slate     { --badge-fg: #0a0f15; }
-.dark .bg-neutral,   [data-theme="dark"] .bg-neutral   { --badge-fg: #0a0f15; }
+.bg-orange  { --badge-bg: var(--hue-orange);  --badge-fg: light-dark(#fff, #1a0f00); }
+.bg-amber   { --badge-bg: var(--hue-amber);   --badge-fg: light-dark(#fff, #1a1300); }
+.bg-yellow  { --badge-bg: var(--hue-yellow);  --badge-fg: light-dark(#fff, #1a1700); }
+.bg-green   { --badge-bg: var(--hue-green);   --badge-fg: light-dark(#fff, #001a0e); }
+.bg-emerald { --badge-bg: var(--hue-emerald); --badge-fg: light-dark(#fff, #001a0e); }
+.bg-teal    { --badge-bg: var(--hue-teal);    --badge-fg: light-dark(#fff, #001a1f); }
+.bg-cyan    { --badge-bg: var(--hue-cyan);    --badge-fg: light-dark(#fff, #001a1f); }
+.bg-slate   { --badge-bg: var(--hue-slate);   --badge-fg: light-dark(#fff, #0a0f15); }
+.bg-neutral { --badge-bg: var(--hue-neutral); --badge-fg: light-dark(#fff, #0a0f15); }

--- a/moo-ds/src/css/components/_badge.css
+++ b/moo-ds/src/css/components/_badge.css
@@ -1,19 +1,23 @@
-/* Badge styles - derived from Bootstrap v5.3 */
+/* Badge styles - token-based: every variant sets --badge-bg and --badge-fg */
 
 .badge {
     --badge-padding-x: 0.65em;
     --badge-padding-y: 0.35em;
     --badge-font-size: 0.75em;
     --badge-font-weight: 700;
-    --badge-colour: #fff;
     --badge-border-radius: var(--border-radius, 0.375rem);
+
+    --badge-bg: var(--primary);
+    --badge-fg: #fff;
 
     display: inline-block;
     padding: var(--badge-padding-y) var(--badge-padding-x);
     font-size: var(--badge-font-size);
     font-weight: var(--badge-font-weight);
-    line-height: 1;
-    color: var(--badge-colour);
+    line-height: 1.3;
+    color: var(--badge-fg);
+    background: var(--badge-bg);
+    border: 1px solid transparent;
     text-align: center;
     white-space: nowrap;
     vertical-align: baseline;
@@ -28,9 +32,121 @@
     border-radius: 50rem;
 }
 
-.bg-primary { background-color: var(--primary) !important; }
-.bg-secondary { background-color: #6c757d !important; }
-.bg-success { background-color: var(--green) !important; }
-.bg-danger { background-color: var(--red) !important; }
-.bg-warning { background-color: var(--amber) !important; color: #000 !important; }
-.bg-info { background-color: #0dcaf0 !important; color: #000 !important; }
+.badge.badge-with-icon {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+}
+
+.badge svg {
+    color: currentColor;
+    width: 1em;
+    height: 1em;
+}
+
+/* Muted: tinted background, hue-as-text */
+.badge.badge-muted {
+    background: color-mix(in srgb, var(--badge-bg) 22%, #000);
+    color: color-mix(in srgb, var(--badge-bg) 45%, #fff);
+    border-color: transparent;
+}
+
+/* Outline: transparent background, hue border + text */
+.badge.badge-outline {
+    background: transparent;
+    color: color-mix(in srgb, var(--badge-bg) 45%, #fff);
+    border-color: var(--badge-bg);
+}
+
+/* Light-mode muted/outline overrides - more contrast against white surfaces */
+@media (prefers-color-scheme: light) {
+    .badge.badge-muted {
+        background: color-mix(in srgb, var(--badge-bg) 16%, #fff);
+        color: color-mix(in srgb, var(--badge-bg) 78%, #000);
+    }
+
+    .badge.badge-outline {
+        color: color-mix(in srgb, var(--badge-bg) 78%, #000);
+    }
+}
+
+.light .badge.badge-muted,
+[data-theme="light"] .badge.badge-muted {
+    background: color-mix(in srgb, var(--badge-bg) 16%, #fff);
+    color: color-mix(in srgb, var(--badge-bg) 78%, #000);
+}
+
+.light .badge.badge-outline,
+[data-theme="light"] .badge.badge-outline {
+    color: color-mix(in srgb, var(--badge-bg) 78%, #000);
+}
+
+.dark .badge.badge-muted,
+[data-theme="dark"] .badge.badge-muted {
+    background: color-mix(in srgb, var(--badge-bg) 22%, #000);
+    color: color-mix(in srgb, var(--badge-bg) 45%, #fff);
+}
+
+.dark .badge.badge-outline,
+[data-theme="dark"] .badge.badge-outline {
+    color: color-mix(in srgb, var(--badge-bg) 45%, #fff);
+}
+
+/* ---- Semantic background tokens ---- */
+.bg-primary   { --badge-bg: var(--primary); --badge-fg: #fff; }
+.bg-secondary { --badge-bg: #6c757d;        --badge-fg: #fff; }
+.bg-success   { --badge-bg: var(--green);   --badge-fg: #fff; }
+.bg-danger    { --badge-bg: var(--red);     --badge-fg: #fff; }
+.bg-warning   { --badge-bg: var(--amber);   --badge-fg: #000; }
+.bg-info      { --badge-bg: #0dcaf0;        --badge-fg: #000; }
+
+/* ---- Hue tokens ----
+   Default (dark-mode) foregrounds. Light-mode block below switches the
+   darker light-mode hues to white text for contrast. */
+.bg-blue    { --badge-bg: var(--hue-blue);    --badge-fg: #fff; }
+.bg-indigo  { --badge-bg: var(--hue-indigo);  --badge-fg: #fff; }
+.bg-purple  { --badge-bg: var(--hue-purple);  --badge-fg: #fff; }
+.bg-pink    { --badge-bg: var(--hue-pink);    --badge-fg: #fff; }
+.bg-rose    { --badge-bg: var(--hue-rose);    --badge-fg: #fff; }
+.bg-orange  { --badge-bg: var(--hue-orange);  --badge-fg: #1a0f00; }
+.bg-amber   { --badge-bg: var(--hue-amber);   --badge-fg: #1a1300; }
+.bg-yellow  { --badge-bg: var(--hue-yellow);  --badge-fg: #1a1700; }
+.bg-green   { --badge-bg: var(--hue-green);   --badge-fg: #001a0e; }
+.bg-emerald { --badge-bg: var(--hue-emerald); --badge-fg: #001a0e; }
+.bg-teal    { --badge-bg: var(--hue-teal);    --badge-fg: #001a1f; }
+.bg-cyan    { --badge-bg: var(--hue-cyan);    --badge-fg: #001a1f; }
+.bg-slate   { --badge-bg: var(--hue-slate);   --badge-fg: #0a0f15; }
+.bg-neutral { --badge-bg: var(--hue-neutral); --badge-fg: #0a0f15; }
+
+/* Light-mode hue foregrounds - the darker hues need white text for contrast. */
+@media (prefers-color-scheme: light) {
+    .bg-orange,
+    .bg-amber,
+    .bg-yellow,
+    .bg-green,
+    .bg-emerald,
+    .bg-teal,
+    .bg-cyan,
+    .bg-slate,
+    .bg-neutral { --badge-fg: #fff; }
+}
+
+.light .bg-orange,    [data-theme="light"] .bg-orange,
+.light .bg-amber,     [data-theme="light"] .bg-amber,
+.light .bg-yellow,    [data-theme="light"] .bg-yellow,
+.light .bg-green,     [data-theme="light"] .bg-green,
+.light .bg-emerald,   [data-theme="light"] .bg-emerald,
+.light .bg-teal,      [data-theme="light"] .bg-teal,
+.light .bg-cyan,      [data-theme="light"] .bg-cyan,
+.light .bg-slate,     [data-theme="light"] .bg-slate,
+.light .bg-neutral,   [data-theme="light"] .bg-neutral { --badge-fg: #fff; }
+
+.dark .bg-orange,    [data-theme="dark"] .bg-orange    { --badge-fg: #1a0f00; }
+.dark .bg-amber,     [data-theme="dark"] .bg-amber     { --badge-fg: #1a1300; }
+.dark .bg-yellow,    [data-theme="dark"] .bg-yellow    { --badge-fg: #1a1700; }
+.dark .bg-green,     [data-theme="dark"] .bg-green     { --badge-fg: #001a0e; }
+.dark .bg-emerald,   [data-theme="dark"] .bg-emerald   { --badge-fg: #001a0e; }
+.dark .bg-teal,      [data-theme="dark"] .bg-teal      { --badge-fg: #001a1f; }
+.dark .bg-cyan,      [data-theme="dark"] .bg-cyan      { --badge-fg: #001a1f; }
+.dark .bg-slate,     [data-theme="dark"] .bg-slate     { --badge-fg: #0a0f15; }
+.dark .bg-neutral,   [data-theme="dark"] .bg-neutral   { --badge-fg: #0a0f15; }

--- a/storybook/src/stories/components/Badge.stories.tsx
+++ b/storybook/src/stories/components/Badge.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useEffect, type ReactElement } from "react";
 import { Badge } from "@andrewmclachlan/moo-ds";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
@@ -13,6 +14,31 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+/**
+ * Swap the global Storybook `.dark` body class for `.light` while the story is
+ * mounted. The preview-level decorator sets `dark` on every story, so without
+ * this the "Light mode contrast" story would still render under dark-mode rules.
+ */
+const ForceLightTheme = (Story: () => ReactElement) => {
+    useEffect(() => {
+        const body = document.body;
+        const prevClasses = body.className;
+        const prevTheme = body.getAttribute("data-theme");
+        body.classList.remove("dark");
+        body.classList.add("light");
+        body.setAttribute("data-theme", "light");
+        return () => {
+            body.className = prevClasses;
+            if (prevTheme) {
+                body.setAttribute("data-theme", prevTheme);
+            } else {
+                body.removeAttribute("data-theme");
+            }
+        };
+    }, []);
+    return <Story />;
+};
 
 const semantics = ["primary", "secondary", "success", "danger", "warning", "info"] as const;
 const hues = [
@@ -74,8 +100,9 @@ export const AllHuesOutline: Story = {
 
 export const LightModeContrast: Story = {
     name: "Light mode contrast",
+    decorators: [ForceLightTheme],
     render: () => (
-        <div className="light" data-theme="light" style={{ background: "#fff", padding: "1rem", ...stack }}>
+        <div style={stack}>
             <div style={row}>{hues.map((bg) => <Badge key={`s-${bg}`} bg={bg}>{bg}</Badge>)}</div>
             <div style={row}>{hues.map((bg) => <Badge key={`m-${bg}`} bg={bg} muted>{bg}</Badge>)}</div>
             <div style={row}>{hues.map((bg) => <Badge key={`o-${bg}`} bg={bg} outline>{bg}</Badge>)}</div>

--- a/storybook/src/stories/components/Badge.stories.tsx
+++ b/storybook/src/stories/components/Badge.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Badge } from "@andrewmclachlan/moo-ds";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const meta = {
     title: "Moo App/Components/Badge",
@@ -13,29 +14,132 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const semantics = ["primary", "secondary", "success", "danger", "warning", "info"] as const;
+const hues = [
+    "blue", "indigo", "purple", "pink", "rose",
+    "orange", "amber", "yellow",
+    "green", "emerald", "teal", "cyan",
+    "slate", "neutral",
+] as const;
+
+const row: React.CSSProperties = { display: "flex", flexWrap: "wrap", gap: "0.5rem", marginBottom: "0.75rem" };
+const stack: React.CSSProperties = { display: "flex", flexDirection: "column", gap: "0.25rem" };
+
 export const Default: Story = {
     render: () => <Badge>Badge</Badge>,
 };
 
-export const Variants: Story = {
+export const Semantic: Story = {
     render: () => (
-        <div style={{ display: "flex", gap: "0.5rem" }}>
-            <Badge bg="primary">Primary</Badge>
-            <Badge bg="secondary">Secondary</Badge>
-            <Badge bg="success">Success</Badge>
-            <Badge bg="danger">Danger</Badge>
-            <Badge bg="warning">Warning</Badge>
-            <Badge bg="info">Info</Badge>
+        <div style={row}>
+            {semantics.map((bg) => (
+                <Badge key={bg} bg={bg}>{bg}</Badge>
+            ))}
+        </div>
+    ),
+};
+
+export const AllHuesSolid: Story = {
+    name: "All hues — solid",
+    render: () => (
+        <div style={row}>
+            {hues.map((bg) => (
+                <Badge key={bg} bg={bg}>{bg}</Badge>
+            ))}
+        </div>
+    ),
+};
+
+export const AllHuesMuted: Story = {
+    name: "All hues — muted",
+    render: () => (
+        <div style={row}>
+            {hues.map((bg) => (
+                <Badge key={bg} bg={bg} muted>{bg}</Badge>
+            ))}
+        </div>
+    ),
+};
+
+export const AllHuesOutline: Story = {
+    name: "All hues — outline",
+    render: () => (
+        <div style={row}>
+            {hues.map((bg) => (
+                <Badge key={bg} bg={bg} outline>{bg}</Badge>
+            ))}
+        </div>
+    ),
+};
+
+export const LightModeContrast: Story = {
+    name: "Light mode contrast",
+    render: () => (
+        <div className="light" data-theme="light" style={{ background: "#fff", padding: "1rem", ...stack }}>
+            <div style={row}>{hues.map((bg) => <Badge key={`s-${bg}`} bg={bg}>{bg}</Badge>)}</div>
+            <div style={row}>{hues.map((bg) => <Badge key={`m-${bg}`} bg={bg} muted>{bg}</Badge>)}</div>
+            <div style={row}>{hues.map((bg) => <Badge key={`o-${bg}`} bg={bg} outline>{bg}</Badge>)}</div>
         </div>
     ),
 };
 
 export const Pills: Story = {
     render: () => (
-        <div style={{ display: "flex", gap: "0.5rem" }}>
-            <Badge pill bg="primary">Primary</Badge>
-            <Badge pill bg="success">Success</Badge>
-            <Badge pill bg="danger">Danger</Badge>
+        <div style={stack}>
+            <div style={row}>{hues.map((bg) => <Badge key={bg} bg={bg} pill>{bg}</Badge>)}</div>
+            <div style={row}>{hues.map((bg) => <Badge key={bg} bg={bg} pill muted>{bg}</Badge>)}</div>
+            <div style={row}>{hues.map((bg) => <Badge key={bg} bg={bg} pill outline>{bg}</Badge>)}</div>
+        </div>
+    ),
+};
+
+export const CustomColour: Story = {
+    name: "Custom colour",
+    render: () => (
+        <div style={stack}>
+            <div style={row}>
+                <Badge colour="#7c6cff">Hex</Badge>
+                <Badge colour="rgb(255, 99, 132)">RGB</Badge>
+                <Badge colour="hsl(160, 70%, 45%)">HSL</Badge>
+                <Badge colour="var(--primary)">CSS var</Badge>
+                <Badge colour="#fde68a" textColour="#78350f">Light bg, dark text</Badge>
+            </div>
+            <div style={row}>
+                <Badge colour="#7c6cff" muted>Muted</Badge>
+                <Badge colour="#7c6cff" outline>Outline</Badge>
+                <Badge colour="#7c6cff" pill>Pill</Badge>
+            </div>
+        </div>
+    ),
+};
+
+export const WithIcon: Story = {
+    name: "With icon",
+    render: () => (
+        <div style={stack}>
+            <div style={row}>
+                <Badge bg="primary" icon={<FontAwesomeIcon icon="star" />}>Featured</Badge>
+                <Badge bg="success" icon={<FontAwesomeIcon icon="check" />}>Done</Badge>
+                <Badge bg="danger" icon={<FontAwesomeIcon icon="circle-xmark" />}>Failed</Badge>
+                <Badge bg="warning" icon={<FontAwesomeIcon icon="triangle-exclamation" />}>Warning</Badge>
+            </div>
+            <div style={row}>
+                <Badge bg="indigo" muted icon={<FontAwesomeIcon icon="bolt" />}>Muted</Badge>
+                <Badge bg="teal" outline icon={<FontAwesomeIcon icon="leaf" />}>Outline</Badge>
+                <Badge bg="rose" pill icon={<FontAwesomeIcon icon="heart" />}>Pill</Badge>
+            </div>
+        </div>
+    ),
+};
+
+export const Composition: Story = {
+    render: () => (
+        <div style={stack}>
+            <div style={row}>
+                <Badge bg="purple" muted pill icon={<FontAwesomeIcon icon="user" />}>muted + pill + icon</Badge>
+                <Badge bg="emerald" outline pill icon={<FontAwesomeIcon icon="check" />}>outline + pill</Badge>
+                <Badge colour="#7c6cff" muted icon={<FontAwesomeIcon icon="bolt" />}>custom + muted + icon</Badge>
+            </div>
         </div>
     ),
 };


### PR DESCRIPTION
## Summary

Expands `Badge` (`@andrewmclachlan/moo-ds`) per the
[palette-expansion handoff](../../../../K%3A/Dev/Apps/MooBank-Visual/docs/handoffs/moo-ds-badge-palette-expansion.md):

- **`muted` / `outline` boolean props** — same hue, different treatment. `outline` wins if both are passed.
- **14 new hue tokens** for `bg`: `blue`, `indigo`, `purple`, `pink`, `rose`, `orange`, `amber`, `yellow`, `green`, `emerald`, `teal`, `cyan`, `slate`, `neutral`. Existing 6 semantic variants are unchanged.
- **`colour` / `textColour` props** as an escape hatch — any CSS colour value (hex, `rgb`, `hsl`, `var(--…)`). When supplied, overrides `bg`.
- **Optional `icon` prop** (`React.ReactNode`) renders before children and inherits the resolved foreground via `currentColor`.
- **Token-based CSS**: every variant sets just `--badge-bg` / `--badge-fg`, so `muted` / `outline` derive contrast generically via `color-mix`.
- Dark- and light-mode hue values tuned for legibility; per-hue foreground overrides where bright vs darker theme variants need different text colours.
- `ComboBoxSelectedItem` migrated from `bg="none"` sentinel + inline `backgroundColor` to the new `colour` prop — the use case it was designed for.

## Backward compatibility

- All six semantic variants (`primary`, `secondary`, `success`, `danger`, `warning`, `info`) render identically.
- `bg`'s type tightens from `string` to a named union; the only internal consumer (`ComboBoxSelectedItem`) is refactored in this PR.

## Test plan

- [x] `npx vitest run` in `moo-ds` — 1169 tests pass
- [x] `npm run build --workspace=@andrewmclachlan/moo-ds` — clean
- [x] `npm run build --workspace=@andrewmclachlan/demoo` — clean
- [ ] Visually check demoo `/components` and Storybook Badge stories in light + dark themes
- [ ] Visually check `ComboBox` selected items render with the same colours as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)