### PR TITLE
Style color inputs with .form-control as Bootstrap swatch pickers

### DIFF
--- a/moo-ds/src/css/components/_forms.css
+++ b/moo-ds/src/css/components/_forms.css
@@ -49,6 +49,26 @@ input.form-control {
     }
 }
 
+input[type="color"].form-control {
+    width: 3rem;
+    height: calc(1.5em + 0.75rem + calc(var(--border-width, 1px) * 2));
+    padding: 0.375rem;
+
+    &:not(:disabled):not([readonly]) {
+        cursor: pointer;
+    }
+
+    &::-moz-color-swatch {
+        border: 0 !important;
+        border-radius: var(--border-radius, 0.375rem);
+    }
+
+    &::-webkit-color-swatch {
+        border: 0 !important;
+        border-radius: var(--border-radius, 0.375rem);
+    }
+}
+
 textarea.form-control {
     min-height: calc(1.5em + 0.75rem + calc(var(--border-width, 1px) * 2));
 }


### PR DESCRIPTION
## Summary
- Adds `input[type=\"color\"].form-control` rules mirroring Bootstrap 5.3's `.form-control-color`: 3rem square, padded swatch, pointer cursor, and zero-border `::-moz-color-swatch` / `::-webkit-color-swatch` pseudo-elements honoring `--border-radius`.

## Test plan
- [ ] Render an `<input type=\"color\" class=\"form-control\">` and confirm it appears as a 3rem square swatch picker rather than a stretched text-style input.
- [ ] Verify the swatch corners are rounded to match the input frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)