### PR TITLE
Fit mobile sidebar drawer to its content

### DIFF
--- a/moo-app/src/layout/Mobile/Sidebar.tsx
+++ b/moo-app/src/layout/Mobile/Sidebar.tsx
@@ -8,7 +8,7 @@ export const Sidebar: SidebarComponent = ({ navItems = [] }) => {
     const layout = useLayout();
 
     return (
-        <Drawer show={layout.showSidebar} onHide={() => layout.setShowSidebar(false)}>
+        <Drawer show={layout.showSidebar} onHide={() => layout.setShowSidebar(false)} className="sidebar-drawer">
             <Drawer.Header closeButton />
             <Drawer.Body className="d-lg-none sidebar">
                 <Nav column>

--- a/moo-ds/src/css/layout/_sidebar.css
+++ b/moo-ds/src/css/layout/_sidebar.css
@@ -91,3 +91,27 @@
         border-top: 1px solid var(--border-colour);
     }
 }
+
+/* Mobile sidebar drawer: drawer wraps a .sidebar and should not add
+   extra padding/width around it. The close button overlays the top-right
+   corner so the sidebar fills the full drawer height. */
+.offcanvas.sidebar-drawer {
+    --offcanvas-width: 200px;
+    --offcanvas-padding-x: 0;
+    --offcanvas-padding-y: 0;
+}
+
+.offcanvas.sidebar-drawer .offcanvas-header {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 0.5rem;
+    z-index: 2;
+}
+
+.offcanvas.sidebar-drawer .offcanvas-body.sidebar {
+    width: 100%;
+    min-width: 0;
+    border-right: 0;
+    padding-top: 3rem;
+}


### PR DESCRIPTION
## Summary
- The mobile sidebar drawer was 400px wide while the inner `.sidebar` is 200px, leaving a dead gap on the right.
- Adds a `.sidebar-drawer` modifier on the `Drawer`: narrows the offcanvas to the sidebar width, removes inner padding, absolutely positions the close button at the top-right, and pads the nav top so it doesn't collide with the X.

## Test plan
- [ ] Open demoo at a mobile viewport (<992px) and hit the hamburger.
- [ ] Drawer fills the full viewport height, width matches the nav content, close icon (X) visible top-right and dismisses the drawer.
- [ ] Selecting a nav item closes the drawer and navigates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)