### PR TITLE
Add badge variant to IconButton

### DIFF
--- a/demoo/src/App.css
+++ b/demoo/src/App.css
@@ -64,3 +64,9 @@
   word-break: break-word;
   color: var(--muted-colour, #6c757d);
 }
+
+.section.buttons {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}

--- a/demoo/src/routes/Components.tsx
+++ b/demoo/src/routes/Components.tsx
@@ -14,9 +14,9 @@ export const Components = () => {
     const [showWarning, setShowWarning] = useState(true);
 
     return (
-        <Page title="Components" breadcrumbs={[{ route: "/components", text: "Components" }]} navItems={[{ route: "/components/iconlinkbutton", image: <Tags />, text: "Icon Link Button" }, { route: "/components/iconbutton", image: <Tags />, text: "Icon Button" }, <NavItemDivider />,
+        <Page title="Components" breadcrumbs={[{ route: "/components", text: "Components" }]} navItems={[{ route: "/components/icon-link-button", image: <Tags />, text: "Icon Link Button" }, { route: "/components/icon-button", image: <Tags />, text: "Icon Button" }, <NavItemDivider />,
         { route: "/components/tag-panel", image: <Tags />, text: "Tag Panel" }]} actions={[<IconButton icon={faPlus} key="create">Create</IconButton>]}>
-            <Section title="Buttons">
+            <Section className="buttons" title="Buttons">
                 <Button size="sm" variant="link">Sample</Button>
                 <Button>Sample 2</Button>
                 <Button variant="outline-primary">Sample 3</Button>

--- a/demoo/src/routes/components/IconButtonComponent.tsx
+++ b/demoo/src/routes/components/IconButtonComponent.tsx
@@ -5,9 +5,14 @@ import { HamburgerMenu } from "@andrewmclachlan/moo-icons";
 export const IconButtonComponent = () => {
     return (
         <Page title="Icon Button">
-            <Section title="Icon Button">
+            <Section className="buttons" title="Icon Button">
                 <IconButton icon="plus" variant="primary">Create</IconButton>
                 <IconButton icon={HamburgerMenu} variant="warning">Create</IconButton>
+            </Section>
+            <Section className="buttons" title="Badge">
+                <IconButton icon="plus" variant="primary" badge>Add Account</IconButton>
+                <IconButton icon="plus" variant="danger" badge>Add Account</IconButton>
+                <IconButton icon="plus" variant="success" badge>Add Account</IconButton>
             </Section>
         </Page>
     );

--- a/demoo/src/routes/components/IconLinkButtonComponent.tsx
+++ b/demoo/src/routes/components/IconLinkButtonComponent.tsx
@@ -5,7 +5,7 @@ import { HamburgerMenu } from "@andrewmclachlan/moo-icons";
 export const IconLinkButtonComponent = () => {
     return (
         <Page title="Icon Link Button">
-            <Section title="Icon Link Button">
+            <Section className="buttons" title="Icon Link Button">
                 <IconLinkButton to="/components" icon="plus" variant="primary">Create</IconLinkButton>
                 <IconLinkButton to="/components" icon={HamburgerMenu} variant="warning">Create</IconLinkButton>
             </Section>

--- a/moo-ds/src/components/IconButton.tsx
+++ b/moo-ds/src/components/IconButton.tsx
@@ -16,7 +16,7 @@ export const IconButton: React.FC<PropsWithChildren<IconButtonProps>> = ({ child
 export interface IconButtonProps extends ButtonProps {
     icon?: IconType;
     iconSrc?: string;
-    /** Render the icon inside a contrasting circular badge (as in "Add" buttons). Designed for solid variants. */
+    /** Render the icon in a full-height split panel on the left, divided from the label by a convex sweep (as in "Add" buttons). Designed for solid variants. */
     badge?: boolean;
 }
 

--- a/moo-ds/src/components/IconButton.tsx
+++ b/moo-ds/src/components/IconButton.tsx
@@ -4,13 +4,20 @@ import { Button, type ButtonProps } from "./Button";
 import { type IconType } from "../types";
 import { Icon } from "./Icon";
 
-export const IconButton: React.FC<PropsWithChildren<IconButtonProps>> = ({ children, icon, iconSrc: src, className, ...button }) => (
-    <Button className={classNames(className, "btn-icon")} {...button}><div><Icon icon={icon} src={src} /><span>{children}</span></div></Button>
+export const IconButton: React.FC<PropsWithChildren<IconButtonProps>> = ({ children, icon, iconSrc: src, badge, className, ...button }) => (
+    <Button className={classNames(className, "btn-icon", badge && "btn-icon-badge")} {...button}>
+        {badge
+            ? <span className="btn-icon-panel"><Icon icon={icon} src={src} /></span>
+            : <Icon icon={icon} src={src} />}
+        <span>{children}</span>
+    </Button>
 );
 
 export interface IconButtonProps extends ButtonProps {
     icon?: IconType;
     iconSrc?: string;
+    /** Render the icon inside a contrasting circular badge (as in "Add" buttons). Designed for solid variants. */
+    badge?: boolean;
 }
 
 IconButton.displayName = "IconButton";

--- a/moo-ds/src/components/__tests__/IconButton.test.tsx
+++ b/moo-ds/src/components/__tests__/IconButton.test.tsx
@@ -34,6 +34,24 @@ describe('IconButton', () => {
     });
   });
 
+  describe('badge', () => {
+    it('applies btn-icon-badge class and wraps the icon in a panel when badge is true', () => {
+      const { container } = render(<IconButton icon={faCheck} badge>Add</IconButton>);
+
+      expect(screen.getByRole('button')).toHaveClass('btn-icon-badge');
+      const panel = container.querySelector('.btn-icon-panel');
+      expect(panel).toBeInTheDocument();
+      expect(panel?.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('omits the badge class and panel wrapper by default', () => {
+      const { container } = render(<IconButton icon={faCheck}>Add</IconButton>);
+
+      expect(screen.getByRole('button')).not.toHaveClass('btn-icon-badge');
+      expect(container.querySelector('.btn-icon-panel')).not.toBeInTheDocument();
+    });
+  });
+
   describe('button variants', () => {
     it('applies primary variant', () => {
       render(<IconButton icon={faCheck} variant="primary">Primary</IconButton>);

--- a/moo-ds/src/css/components/_icon-button.css
+++ b/moo-ds/src/css/components/_icon-button.css
@@ -16,14 +16,8 @@
     width: 18px;
 }
 
-/* Split "badge" icon button: a full-height panel on the left holds the icon,
-   divided from the label by a convex (bulging) curve. The panel is a lighter
-   (not desaturated) shade of the button background; the icon follows the button
-   text colour (currentColor). Designed for solid variants. */
 .btn.btn-icon-badge {
     --badge-bulge: 1.25rem;     /* horizontal radius of the bulge */
-    /* lighter than the button background but NOT desaturated: raise OKLCH
-       lightness only, keeping chroma (c) and hue (h) intact */
     --badge-bg: oklch(from var(--btn-bg) calc(l + 0.15) c h);
     /* dividing line drawn along the sweep */
     --badge-divider: var(--section-bg);

--- a/moo-ds/src/css/components/_icon-button.css
+++ b/moo-ds/src/css/components/_icon-button.css
@@ -16,22 +16,16 @@
     width: 18px;
 }
 
-/* Split "badge" icon button: a full-height light panel on the left holds the
-   icon, divided from the label by a convex (bulging) curve. Colours invert the
-   button — panel takes the foreground colour (white on solid variants), icon
-   takes the button background. Designed for solid variants. */
 .btn.btn-icon-badge {
     --badge-bulge: 1.25rem;     /* horizontal radius of the bulge */
-    /* lighter than the button background but NOT desaturated: raise OKLCH
-       lightness only, keeping chroma (c) and hue (h) intact */
     --badge-bg: oklch(from var(--btn-bg) calc(l + 0.15) c h);
     /* dividing line drawn along the sweep */
     --badge-divider: var(--section-bg);
     position: relative;
     overflow: hidden;
-    padding-left: 0;            /* panel runs flush to the left edge */
-    border-width: 0;            /* no button border ringing the panel */
-    gap: 0;                     /* spacing handled by the panel's margin */
+    padding-left: 0;
+    border-width: 0;
+    gap: 0;
 }
 
 .btn.btn-icon-badge .btn-icon-panel {
@@ -45,8 +39,6 @@
     margin: calc(-1 * var(--btn-padding-y) - 2px) 0.625rem calc(-1 * var(--btn-padding-y) - 2px) -2px;
     padding: 0 0.5rem;
     background: var(--badge-bg);
-    /* icon takes the button's background colour; `color` drives FontAwesome
-       (currentColor), fill/stroke drive inline custom SVGs */
     color: currentColor;
     border: 2px solid var(--badge-divider);
     /* convex right edge: elliptical, vertical radius 50% makes a smooth D-curve */

--- a/moo-ds/src/css/components/_icon-button.css
+++ b/moo-ds/src/css/components/_icon-button.css
@@ -1,10 +1,11 @@
 .btn svg {
-    stroke: var(--btn-colour);
-    fill: var(--btn-colour);
+    /* icon takes the current text colour (currentColor === the button's `color`) */
+    stroke: currentColor;
+    fill: currentColor;
 }
 
-.btn.btn-icon div {
-    display: flex;
+.btn.btn-icon {
+    display: inline-flex;
     align-items: center;
     gap: 5px;
 }
@@ -13,4 +14,41 @@
 .btn img.custom-icon {
     height: 18px;
     width: 18px;
+}
+
+/* Split "badge" icon button: a full-height light panel on the left holds the
+   icon, divided from the label by a convex (bulging) curve. Colours invert the
+   button — panel takes the foreground colour (white on solid variants), icon
+   takes the button background. Designed for solid variants. */
+.btn.btn-icon-badge {
+    --badge-bulge: 1.25rem;     /* horizontal radius of the bulge */
+    /* lighter than the button background but NOT desaturated: raise OKLCH
+       lightness only, keeping chroma (c) and hue (h) intact */
+    --badge-bg: oklch(from var(--btn-bg) calc(l + 0.15) c h);
+    /* dividing line drawn along the sweep */
+    --badge-divider: var(--section-bg);
+    position: relative;
+    overflow: hidden;
+    padding-left: 0;            /* panel runs flush to the left edge */
+    border-width: 0;            /* no button border ringing the panel */
+    gap: 0;                     /* spacing handled by the panel's margin */
+}
+
+.btn.btn-icon-badge .btn-icon-panel {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    align-self: stretch;
+    /* bleed past the button's padding AND outer edge so the left/top/bottom
+       borders are clipped by overflow:hidden — only the curved right border
+       (the divider line) stays visible */
+    margin: calc(-1 * var(--btn-padding-y) - 2px) 0.625rem calc(-1 * var(--btn-padding-y) - 2px) -2px;
+    padding: 0 0.5rem;
+    background: var(--badge-bg);
+    /* icon takes the button's background colour; `color` drives FontAwesome
+       (currentColor), fill/stroke drive inline custom SVGs */
+    color: currentColor;
+    border: 2px solid var(--badge-divider);
+    /* convex right edge: elliptical, vertical radius 50% makes a smooth D-curve */
+    border-radius: 0 var(--badge-bulge) var(--badge-bulge) 0 / 0 50% 50% 0;
 }

--- a/moo-ds/src/css/components/_icon-button.css
+++ b/moo-ds/src/css/components/_icon-button.css
@@ -16,8 +16,14 @@
     width: 18px;
 }
 
+/* Split "badge" icon button: a full-height panel on the left holds the icon,
+   divided from the label by a convex (bulging) curve. The panel is a lighter
+   (not desaturated) shade of the button background; the icon follows the button
+   text colour (currentColor). Designed for solid variants. */
 .btn.btn-icon-badge {
     --badge-bulge: 1.25rem;     /* horizontal radius of the bulge */
+    /* lighter than the button background but NOT desaturated: raise OKLCH
+       lightness only, keeping chroma (c) and hue (h) intact */
     --badge-bg: oklch(from var(--btn-bg) calc(l + 0.15) c h);
     /* dividing line drawn along the sweep */
     --badge-divider: var(--section-bg);

--- a/storybook/src/stories/components/IconButton.stories.ts
+++ b/storybook/src/stories/components/IconButton.stories.ts
@@ -49,3 +49,12 @@ export const CustomSVG: Story = {
     icon: Tags,
   },
 };
+
+export const Badge: Story = {
+  args: {
+    title: "Badge",
+    children: "Add Account",
+    icon: Budget,
+    badge: true,
+  },
+};


### PR DESCRIPTION
@
## Summary

Adds an opt-in `badge` prop to `IconButton` that renders the icon in a full-height **split panel** on the left, divided from the label by a convex sweep with a dividing line (think "Add Account" style buttons).

- **Panel colour**: a lighter — but *not* desaturated — shade of the button background, via OKLCH relative colour (`oklch(from var(--btn-bg) calc(l + 0.15) c h)`). Saturation/hue preserved.
- **Divider**: only the curved right edge of the panel is visible; the other three borders bleed past the button edge and are clipped by `overflow: hidden`.
- **Icon colour**: now driven by `currentColor`, so the icon always matches the surrounding text colour.
- **Cleanup**: removed the wrapper `<div>` inside `IconButton` (flex moved onto the button itself).
- Designed for **solid** variants (primary/danger/success). Outline variants are out of scope (transparent `--btn-bg`).

## Examples
- demoo: new "Badge" section on the Icon Button page (primary/danger/success).
- Storybook: new `Badge` story.

## Notes
- Uses CSS relative colour syntax (Chrome/Edge 119+, Safari 16.4+, Firefox 128+) — consistent with existing `light-dark()`/`color-mix()` usage.

## Test plan
- [x] `npm run build -w @andrewmclachlan/moo-ds` passes
- [x] `npm run build -w @andrewmclachlan/demoo` passes
- [ ] Visual check of the three variants in demoo (`/components/icon-button`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@