### PR TITLE
feat(moo-app): optional query cache persistence via queryPersistOptions

### DIFF
--- a/moo-app/package.json
+++ b/moo-app/package.json
@@ -77,6 +77,7 @@
     "@fortawesome/free-solid-svg-icons": "^7.3.0",
     "@fortawesome/react-fontawesome": "^3.3.1",
     "@tanstack/react-query": "^5.101.2",
+    "@tanstack/react-query-persist-client": "^5.101.2",
     "@tanstack/react-router": "^1.170.16",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/moo-app/src/MooApp.tsx
+++ b/moo-app/src/MooApp.tsx
@@ -1,5 +1,6 @@
 import React, { type PropsWithChildren, type ReactNode, useEffect } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { PersistQueryClientProvider, type PersistQueryClientOptions } from "@tanstack/react-query-persist-client";
 import { type AnyRouter, RouterProvider } from "@tanstack/react-router";
 
 import { Link, NavLink } from "./components";
@@ -18,7 +19,7 @@ import { type AxiosInstance } from "axios";
 
 library.add(faArrowRightFromBracket, faMoon, faSun, faTimesCircle);
 
-export const MooApp: React.FC<PropsWithChildren<MooAppProps>> = ({ router, clientId, scopes = [], baseUrl = "/", client, name, version, copyrightYear, authFallback }) => {
+export const MooApp: React.FC<PropsWithChildren<MooAppProps>> = ({ router, clientId, scopes = [], baseUrl = "/", client, name, version, copyrightYear, authFallback, queryPersistOptions }) => {
 
   const [msalInstance, setMsalInstance] = React.useState<any>(null);
 
@@ -59,19 +60,28 @@ export const MooApp: React.FC<PropsWithChildren<MooAppProps>> = ({ router, clien
 
   if (!msalInstance) return null;
 
+  const app = (
+    <LinkProvider LinkComponent={Link} NavLinkComponent={NavLink}>
+      <MessageProvider>
+        <Login authFallback={authFallback}>
+          <RouterProvider router={router} />
+        </Login>
+      </MessageProvider>
+    </LinkProvider>
+  );
+
   return (
     <AppProvider name={name} version={version} copyrightYear={copyrightYear}>
       <MsalProvider instance={msalInstance}>
         <HttpClientProvider client={client} baseUrl={baseUrl} scopes={scopes}>
-          <QueryClientProvider client={queryClient}>
-            <LinkProvider LinkComponent={Link} NavLinkComponent={NavLink}>
-              <MessageProvider>
-                <Login authFallback={authFallback}>
-                  <RouterProvider router={router} />
-                </Login>
-              </MessageProvider>
-            </LinkProvider>
-          </QueryClientProvider>
+          {queryPersistOptions ?
+            <PersistQueryClientProvider client={queryClient} persistOptions={queryPersistOptions}>
+              {app}
+            </PersistQueryClientProvider> :
+            <QueryClientProvider client={queryClient}>
+              {app}
+            </QueryClientProvider>
+          }
         </HttpClientProvider>
       </MsalProvider>
     </AppProvider>
@@ -88,4 +98,5 @@ export interface MooAppProps {
   copyrightYear?: number;
   router: AnyRouter;
   authFallback?: ReactNode;
+  queryPersistOptions?: Omit<PersistQueryClientOptions, "queryClient">;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,6 +134,7 @@
         "@fortawesome/free-solid-svg-icons": "^7.3.0",
         "@fortawesome/react-fontawesome": "^3.3.1",
         "@tanstack/react-query": "^5.101.2",
+        "@tanstack/react-query-persist-client": "^5.101.2",
         "@tanstack/react-router": "^1.170.16",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -2412,9 +2413,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2432,9 +2430,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2452,9 +2447,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2472,9 +2464,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2492,9 +2481,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2512,9 +2498,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2723,9 +2706,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2740,9 +2720,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2755,9 +2732,6 @@
       "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2773,9 +2747,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2790,9 +2761,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2807,9 +2775,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2824,9 +2789,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2841,9 +2803,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2858,9 +2817,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2875,9 +2831,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2892,9 +2845,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2909,9 +2859,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2926,9 +2873,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3508,6 +3452,20 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tanstack/query-persist-client-core": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-persist-client-core/-/query-persist-client-core-5.101.2.tgz",
+      "integrity": "sha512-rgMsbvBVpSPDUsprC9FYxojdG0Q1LH6yq1i3DXz2aps4VEqv2l4Msj3YDqIifU3xkl/DrYe9YWntZAJLrM6xTg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/query-core": "5.101.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/react-query": {
       "version": "5.101.2",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
@@ -3521,6 +3479,24 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-persist-client": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-persist-client/-/react-query-persist-client-5.101.2.tgz",
+      "integrity": "sha512-19UpaRtf0lvB2QAJ2MoixxtGf3osMOd508g99EsttUj4+3eLs+ulnNgYjB7AkQMHrRlcbVXqpVNqWkB4a7g8Zw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/query-persist-client-core": "5.101.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.101.2",
         "react": "^18 || ^19"
       }
     },


### PR DESCRIPTION
Adds an optional `queryPersistOptions?: Omit<PersistQueryClientOptions, "queryClient">` prop to `MooApp`. When supplied, the app is wrapped in `PersistQueryClientProvider` (which gates query mounting until the persisted cache is restored); when omitted, the existing `QueryClientProvider` path is unchanged.

`@tanstack/react-query-persist-client` is added as a peer dependency alongside `@tanstack/react-query` — consumers supply their own persister (e.g. IndexedDB) and dehydrate filter through the options.

Build clean; all 299 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)