### PR TITLE
Fix MSAL block_iframe_reload on silent token renewal (#607)

### DIFF
--- a/moo-app/README.md
+++ b/moo-app/README.md
@@ -8,3 +8,36 @@ An opinionated React library for scaffolding web applications.
 - Uses React Router for creating a SPA
 - Provides an optional layout for a functional app
 - Provides components to allow faster assembly of applications
+
+## Avoiding `block_iframe_reload` on silent token renewal
+
+MSAL renews tokens silently in a hidden iframe that navigates to the app's
+redirect URI. By default that URI is the app itself, so the whole SPA re-boots
+inside the iframe and MSAL aborts with `BrowserAuthError: block_iframe_reload`
+(surfaced most visibly by the profile-photo fetch, but it affects every silent
+renewal).
+
+Following [MSAL's guidance](https://learn.microsoft.com/en-us/entra/msal/javascript/browser/errors#block_iframe_reload),
+point silent renewals at a lightweight blank page that does not load MSAL:
+
+1. Add `public/blank.html` to your app — it needs no scripts:
+
+   ```html
+   <!DOCTYPE html>
+   <html>
+     <head><title></title></head>
+     <body></body>
+   </html>
+   ```
+
+2. Register `<your-origin>/blank.html` as a redirect URI on the app's Azure AD
+   registration (alongside your existing SPA redirect URI).
+
+3. Pass it to `MooApp`:
+
+   ```tsx
+   <MooApp silentRedirectUri={`${window.location.origin}/blank.html`} ... />
+   ```
+
+This is used **only** for silent renewal — interactive login is unchanged and
+still returns the user to the route they started from.

--- a/moo-app/src/MooApp.tsx
+++ b/moo-app/src/MooApp.tsx
@@ -19,12 +19,12 @@ import { type AxiosInstance } from "axios";
 
 library.add(faArrowRightFromBracket, faMoon, faSun, faTimesCircle);
 
-export const MooApp: React.FC<PropsWithChildren<MooAppProps>> = ({ router, clientId, scopes = [], baseUrl = "/", client, name, version, copyrightYear, authFallback, queryPersistOptions }) => {
+export const MooApp: React.FC<PropsWithChildren<MooAppProps>> = ({ router, clientId, scopes = [], baseUrl = "/", client, name, version, copyrightYear, authFallback, queryPersistOptions, redirectUri }) => {
 
   const [msalInstance, setMsalInstance] = React.useState<any>(null);
 
   useEffect(() => {
-    getMsalInstance(clientId).then((instance) => setMsalInstance(instance));
+    getMsalInstance(clientId, { redirectUri }).then((instance) => setMsalInstance(instance));
   }, []);
 
   const [queryClient] = React.useState(() => new QueryClient({
@@ -99,4 +99,13 @@ export interface MooAppProps {
   router: AnyRouter;
   authFallback?: ReactNode;
   queryPersistOptions?: Omit<PersistQueryClientOptions, "queryClient">;
+  /**
+   * Overrides the MSAL redirect URI. Point this at a lightweight page that does
+   * not boot the SPA (e.g. `${window.location.origin}/blank.html`) to stop
+   * silent token renewals re-booting the app inside MSAL's hidden iframe and
+   * emitting `BrowserAuthError: block_iframe_reload` (issue #607). The URI must
+   * also be registered as a redirect URI on the Azure AD app registration.
+   * Defaults to `window.location.origin`.
+   */
+  redirectUri?: string;
 }

--- a/moo-app/src/MooApp.tsx
+++ b/moo-app/src/MooApp.tsx
@@ -19,12 +19,12 @@ import { type AxiosInstance } from "axios";
 
 library.add(faArrowRightFromBracket, faMoon, faSun, faTimesCircle);
 
-export const MooApp: React.FC<PropsWithChildren<MooAppProps>> = ({ router, clientId, scopes = [], baseUrl = "/", client, name, version, copyrightYear, authFallback, queryPersistOptions, redirectUri }) => {
+export const MooApp: React.FC<PropsWithChildren<MooAppProps>> = ({ router, clientId, scopes = [], baseUrl = "/", client, name, version, copyrightYear, authFallback, queryPersistOptions, silentRedirectUri }) => {
 
   const [msalInstance, setMsalInstance] = React.useState<any>(null);
 
   useEffect(() => {
-    getMsalInstance(clientId, { redirectUri }).then((instance) => setMsalInstance(instance));
+    getMsalInstance(clientId, { silentRedirectUri }).then((instance) => setMsalInstance(instance));
   }, []);
 
   const [queryClient] = React.useState(() => new QueryClient({
@@ -100,12 +100,16 @@ export interface MooAppProps {
   authFallback?: ReactNode;
   queryPersistOptions?: Omit<PersistQueryClientOptions, "queryClient">;
   /**
-   * Overrides the MSAL redirect URI. Point this at a lightweight page that does
-   * not boot the SPA (e.g. `${window.location.origin}/blank.html`) to stop
-   * silent token renewals re-booting the app inside MSAL's hidden iframe and
-   * emitting `BrowserAuthError: block_iframe_reload` (issue #607). The URI must
-   * also be registered as a redirect URI on the Azure AD app registration.
-   * Defaults to `window.location.origin`.
+   * Redirect URI used **only** for silent token renewal (MSAL's hidden iframe).
+   * Point this at a lightweight blank page that does not boot the SPA (e.g.
+   * `${window.location.origin}/blank.html`) to stop silent renewals re-booting
+   * the app inside the iframe and emitting `BrowserAuthError: block_iframe_reload`
+   * (issue #607). It does not affect interactive login, which still returns the
+   * user to the route they started from. The URI must also be registered as a
+   * redirect URI on the Azure AD app registration. Defaults to unset (MSAL's
+   * default redirect URI is used).
+   *
+   * @see https://learn.microsoft.com/en-us/entra/msal/javascript/browser/errors#block_iframe_reload
    */
-  redirectUri?: string;
+  silentRedirectUri?: string;
 }

--- a/moo-app/src/login/msal.ts
+++ b/moo-app/src/login/msal.ts
@@ -53,44 +53,55 @@ export const apiRequest: msal.SilentRequest = {
 
 
 /**
- * Options for overriding parts of the MSAL {@link msal.Configuration} at
- * instance-creation time. All properties are optional and default to the
- * historical behaviour, so existing consuming apps are unaffected.
+ * Options for overriding parts of the MSAL configuration at instance-creation
+ * time. All properties are optional and default to the historical behaviour, so
+ * existing consuming apps are unaffected.
  */
 export interface MsalOptions {
     /**
-     * The URI that Azure AD redirects to after authentication. This is also the
-     * page MSAL loads inside the hidden iframe used for silent token renewal.
+     * The redirect URI used **only** for silent token renewal (the hidden iframe
+     * that MSAL opens for `acquireTokenSilent`). It is NOT used for interactive
+     * login, so it does not affect where the user lands after signing in.
      *
-     * Defaults to `window.location.origin` (the app's home page).
-     *
-     * When the default is used, every silent token renewal re-boots the entire
-     * SPA inside the hidden iframe, which MSAL detects and aborts with
-     * `BrowserAuthError: block_iframe_reload` (see issue #607). To avoid this,
-     * point this at a lightweight page that does not boot the SPA — e.g. a
-     * `blank.html` served from your app's `public/` folder:
+     * By default silent renewals use the app's own `redirectUri`
+     * (`window.location.origin`), which causes the whole SPA to re-boot inside
+     * the hidden iframe; MSAL detects this and aborts with
+     * `BrowserAuthError: block_iframe_reload` (see issue #607). Per MSAL's
+     * guidance, point this at a lightweight blank page that does **not** load
+     * MSAL — e.g. a `blank.html` served from your app's `public/` folder:
      *
      * ```ts
-     * <MooApp redirectUri={`${window.location.origin}/blank.html`} ... />
+     * <MooApp silentRedirectUri={`${window.location.origin}/blank.html`} ... />
      * ```
      *
+     * The blank page needs no scripts: the silent iframe returns the response in
+     * its URL hash, which MSAL reads directly. Interactive login is unaffected
+     * and still returns the user to the route they started from
+     * (`navigateToLoginRequestUrl` defaults to `true`).
+     *
      * NOTE: the URI must also be registered as a redirect (reply) URI on the
-     * app's Azure AD registration, otherwise authentication will fail. Interactive
-     * login still returns the user to the originally requested route — MSAL v5
-     * navigates back to the login-request URL by default.
+     * app's Azure AD registration, otherwise silent renewal will fail.
+     *
+     * @see https://learn.microsoft.com/en-us/entra/msal/javascript/browser/errors#block_iframe_reload
      */
-    redirectUri?: string;
+    silentRedirectUri?: string;
 }
 
 let msalInstance: msal.IPublicClientApplication;
+
+let silentRedirectUri: string | undefined;
+
+/**
+ * The redirect URI to apply to silent token requests, or `undefined` to use the
+ * MSAL default. Configured via {@link MsalOptions.silentRedirectUri}.
+ */
+export const getSilentRedirectUri = (): string | undefined => silentRedirectUri;
 
 const getMsalInstance = async (clientId: string, options?: MsalOptions): Promise<msal.IPublicClientApplication> => {
     if (msalInstance) return msalInstance;
 
     msalConfig.auth.clientId = clientId;
-    if (options?.redirectUri) {
-        msalConfig.auth.redirectUri = options.redirectUri;
-    }
+    silentRedirectUri = options?.silentRedirectUri;
     msalConfig.system.loggerOptions = {
         logLevel: msal.LogLevel.Warning
     }

--- a/moo-app/src/login/msal.ts
+++ b/moo-app/src/login/msal.ts
@@ -52,12 +52,45 @@ export const apiRequest: msal.SilentRequest = {
 };
 
 
+/**
+ * Options for overriding parts of the MSAL {@link msal.Configuration} at
+ * instance-creation time. All properties are optional and default to the
+ * historical behaviour, so existing consuming apps are unaffected.
+ */
+export interface MsalOptions {
+    /**
+     * The URI that Azure AD redirects to after authentication. This is also the
+     * page MSAL loads inside the hidden iframe used for silent token renewal.
+     *
+     * Defaults to `window.location.origin` (the app's home page).
+     *
+     * When the default is used, every silent token renewal re-boots the entire
+     * SPA inside the hidden iframe, which MSAL detects and aborts with
+     * `BrowserAuthError: block_iframe_reload` (see issue #607). To avoid this,
+     * point this at a lightweight page that does not boot the SPA — e.g. a
+     * `blank.html` served from your app's `public/` folder:
+     *
+     * ```ts
+     * <MooApp redirectUri={`${window.location.origin}/blank.html`} ... />
+     * ```
+     *
+     * NOTE: the URI must also be registered as a redirect (reply) URI on the
+     * app's Azure AD registration, otherwise authentication will fail. Interactive
+     * login still returns the user to the originally requested route — MSAL v5
+     * navigates back to the login-request URL by default.
+     */
+    redirectUri?: string;
+}
+
 let msalInstance: msal.IPublicClientApplication;
 
-const getMsalInstance = async (clientId: string): Promise<msal.IPublicClientApplication> => {
+const getMsalInstance = async (clientId: string, options?: MsalOptions): Promise<msal.IPublicClientApplication> => {
     if (msalInstance) return msalInstance;
 
     msalConfig.auth.clientId = clientId;
+    if (options?.redirectUri) {
+        msalConfig.auth.redirectUri = options.redirectUri;
+    }
     msalConfig.system.loggerOptions = {
         logLevel: msal.LogLevel.Warning
     }

--- a/moo-app/src/login/msal.ts
+++ b/moo-app/src/login/msal.ts
@@ -70,8 +70,12 @@ export interface MsalOptions {
      * guidance, point this at a lightweight blank page that does **not** load
      * MSAL — e.g. a `blank.html` served from your app's `public/` folder:
      *
-     * ```ts
-     * <MooApp silentRedirectUri={`${window.location.origin}/blank.html`} ... />
+     * ```tsx
+     * <MooApp
+     *     clientId="<client-id>"
+     *     router={router}
+     *     silentRedirectUri={`${window.location.origin}/blank.html`}
+     * />
      * ```
      *
      * The blank page needs no scripts: the silent iframe returns the response in

--- a/moo-app/src/providers/HttpClientProvider.tsx
+++ b/moo-app/src/providers/HttpClientProvider.tsx
@@ -3,7 +3,7 @@ import axios, { type AxiosInstance, type InternalAxiosRequestConfig } from "axio
 
 import { type IMsalContext, useMsal } from "@azure/msal-react";
 import { AuthError, EventType, InteractionStatus, InteractionType, type IPublicClientApplication, type SilentRequest } from "@azure/msal-browser";
-import { loginRequest } from "../login/msal";
+import { getSilentRedirectUri, loginRequest } from "../login/msal";
 
 export interface HttpClientProviderProps {
     client?: AxiosInstance;
@@ -122,9 +122,16 @@ const acquireTokenForRequest = async (
     const account = msal.instance.getActiveAccount() ?? msal.instance.getAllAccounts()[0];
     const redirectState = getRedirectState(msal.instance);
 
+    // Point silent renewals at a blank page (if configured) so the hidden iframe
+    // doesn't re-boot the SPA and trigger block_iframe_reload. Interactive
+    // redirects below intentionally keep the default redirectUri so the user is
+    // returned to the page that initiated login.
+    const silentRedirectUri = getSilentRedirectUri();
+
     const tokenRequest: SilentRequest = {
         scopes: scopes ?? [],
-        ...(account ? { account } : {})
+        ...(account ? { account } : {}),
+        ...(silentRedirectUri ? { redirectUri: silentRedirectUri } : {})
     };
 
     try {

--- a/moo-app/src/providers/__tests__/HttpClientProvider.test.tsx
+++ b/moo-app/src/providers/__tests__/HttpClientProvider.test.tsx
@@ -30,8 +30,13 @@ vi.mock('@azure/msal-react', () => ({
   }),
 }));
 
-vi.mock('../login/msal', () => ({
+const { mockGetSilentRedirectUri } = vi.hoisted(() => ({
+  mockGetSilentRedirectUri: vi.fn<() => string | undefined>(() => undefined),
+}));
+
+vi.mock('../../login/msal', () => ({
   loginRequest: { scopes: ['openid', 'profile'] },
+  getSilentRedirectUri: mockGetSilentRedirectUri,
 }));
 
 describe('HttpClientProvider', () => {
@@ -164,6 +169,10 @@ describe('addMsalInterceptor', () => {
     return client;
   };
 
+  beforeEach(() => {
+    mockGetSilentRedirectUri.mockReturnValue(undefined);
+  });
+
   it('adds request interceptor to client', () => {
     const client = axios.create();
     const originalCount = client.interceptors.request.handlers.length;
@@ -183,6 +192,30 @@ describe('addMsalInterceptor', () => {
     const response = await client.get('/api/data');
 
     expect(response.config.headers.getAuthorization()).toBe('Bearer test-token-123');
+  });
+
+  it('passes the configured silent redirect URI to acquireTokenSilent', async () => {
+    const acquireTokenSilent = vi.fn().mockResolvedValue({ accessToken: 'test-token-123' });
+    const msal = createMockMsal({ acquireTokenSilent });
+    mockGetSilentRedirectUri.mockReturnValue('https://app.example.com/blank.html');
+    const client = createClientWithInterceptor(msal);
+
+    await client.get('/api/data');
+
+    expect(acquireTokenSilent).toHaveBeenCalledWith(
+      expect.objectContaining({ redirectUri: 'https://app.example.com/blank.html' })
+    );
+  });
+
+  it('omits redirectUri from the silent request when none is configured', async () => {
+    const acquireTokenSilent = vi.fn().mockResolvedValue({ accessToken: 'test-token-123' });
+    const msal = createMockMsal({ acquireTokenSilent });
+    mockGetSilentRedirectUri.mockReturnValue(undefined);
+    const client = createClientWithInterceptor(msal);
+
+    await client.get('/api/data');
+
+    expect(acquireTokenSilent.mock.calls[0][0]).not.toHaveProperty('redirectUri');
   });
 
   it('does not set Authorization header when acquireTokenSilent returns no accessToken', async () => {

--- a/moo-app/src/services/__tests__/msgraph.test.tsx
+++ b/moo-app/src/services/__tests__/msgraph.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const mockGet = vi.fn();
+const mockEject = vi.fn();
+
+vi.mock('@azure/msal-react', () => ({
+  useMsal: () => ({
+    instance: { getActiveAccount: () => ({ homeAccountId: 'test-account' }) },
+    accounts: [{ homeAccountId: 'test-account' }],
+  }),
+}));
+
+vi.mock('../../providers/HttpClientProvider', () => ({
+  createHttpClient: () => ({
+    interceptors: { request: { eject: mockEject } },
+    get: mockGet,
+  }),
+  addMsalInterceptor: () => 1,
+}));
+
+import { usePhoto } from '../msgraph';
+
+describe('usePhoto photo-fetch error handling', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockGet.mockReset();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    debugSpy.mockRestore();
+  });
+
+  it('does not warn when the request is canceled (e.g. block_iframe_reload redirect handoff)', async () => {
+    mockGet.mockRejectedValue({ code: 'ERR_CANCELED' });
+
+    renderHook(() => usePhoto());
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    // Give the rejected promise a tick to settle.
+    await Promise.resolve();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs at debug (not warn) when the user has no photo (404)', async () => {
+    mockGet.mockRejectedValue({ response: { status: 404 } });
+
+    renderHook(() => usePhoto());
+
+    await waitFor(() => expect(debugSpy).toHaveBeenCalled());
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns on a genuine, unexpected error', async () => {
+    mockGet.mockRejectedValue({ response: { status: 500 } });
+
+    renderHook(() => usePhoto());
+
+    await waitFor(() => expect(warnSpy).toHaveBeenCalled());
+  });
+});

--- a/moo-app/src/services/__tests__/msgraph.test.tsx
+++ b/moo-app/src/services/__tests__/msgraph.test.tsx
@@ -54,15 +54,16 @@ describe('usePhoto photo-fetch error handling', () => {
 
     renderHook(() => usePhoto());
 
-    await waitFor(() => expect(debugSpy).toHaveBeenCalled());
+    await waitFor(() => expect(debugSpy).toHaveBeenCalledWith('No photo found for user'));
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('warns on a genuine, unexpected error', async () => {
-    mockGet.mockRejectedValue({ response: { status: 500 } });
+    const error = { response: { status: 500 } };
+    mockGet.mockRejectedValue(error);
 
     renderHook(() => usePhoto());
 
-    await waitFor(() => expect(warnSpy).toHaveBeenCalled());
+    await waitFor(() => expect(warnSpy).toHaveBeenCalledWith('Error fetching user photo', error));
   });
 });

--- a/moo-app/src/services/msgraph.ts
+++ b/moo-app/src/services/msgraph.ts
@@ -35,9 +35,19 @@ export const usePhoto = () => {
                 URL.revokeObjectURL(objectUrl);
             }
         }).catch((error) => {
-            if (error?.code !== "ERR_CANCELED") {
-                console.warn("No photo found for user", error);
+            // The request was aborted, or the interceptor could not acquire a
+            // token silently (e.g. block_iframe_reload / InteractionRequired) and
+            // handed off to an interactive redirect. Not an error — just skip.
+            if (error?.code === "ERR_CANCELED") {
+                return;
             }
+            // 404 is the expected response when the account has no profile photo.
+            if (error?.response?.status === 404) {
+                console.debug("No photo found for user");
+                return;
+            }
+            // Anything else is a genuine, unexpected failure worth surfacing.
+            console.warn("Error fetching user photo", error);
         });
 
         return () => {


### PR DESCRIPTION
Fixes #607

## Root cause

MSAL renews tokens silently in a hidden iframe that navigates to the app's configured `redirectUri`. By default that URI is the app itself (`window.location.origin`), so the entire SPA re-boots **inside** the iframe. MSAL detects the iframe navigating back to an app URL with an auth response and aborts with `BrowserAuthError: block_iframe_reload` (confirmed in `@azure/msal-browser@5.17.0` `RedirectClient` / `BrowserUtils.blockReloadInHiddenIframes()`). This affects **all** silent renewals; the profile-photo fetch is just the most visible trigger on load.

## Fix (per MSAL's documented guidance)

Set the blank `redirectUri` **only on silent token requests**, not on the global `auth.redirectUri`:

- Add `MsalOptions.silentRedirectUri`, stored in the msal module and exposed via `getSilentRedirectUri()`.
- Apply it as `redirectUri` on the `SilentRequest` in `acquireTokenForRequest` (HttpClientProvider) — this covers both API tokens and the Graph photo, since both flow through that interceptor.
- Leave `auth.redirectUri = window.location.origin` **untouched**, so interactive login still returns the user to the route they started from (`navigateToLoginRequestUrl` defaults to `true`).
- Rename the `MooApp` prop `redirectUri` → `silentRedirectUri`; document the `blank.html` setup in the README.
- Photo fetch: skip silently on `ERR_CANCELED`, log the expected no-photo (404) case at `console.debug`, keep genuine errors at `console.warn`.

### Why not override the global `auth.redirectUri`?

The [MSAL docs](https://learn.microsoft.com/en-us/entra/msal/javascript/browser/errors#block_iframe_reload) recommend the blank page **per silent request**, and state the global `redirectUri` page **must load MSAL to process the response**. Pointing the global `auth.redirectUri` at a static `blank.html` would therefore break interactive redirect login — the user would land on the blank page and never be returned to the route they left. The per-request approach fixes every silent renewal while leaving the login flow (and "return to the page you left") intact. See [Avoid page reloads (MSAL.js)](https://learn.microsoft.com/en-us/entra/identity-platform/msal-js-avoid-page-reloads).

**Correction to an earlier note:** `navigateToLoginRequestUrl` was **not** removed in MSAL v5 — it moved from static `Configuration.auth` to a per-call `handleRedirectPromise` option, still defaulting to `true`. `@azure/msal-react`'s `MsalProvider` calls `handleRedirectPromise()` with no args, so route-return remains on by default.

## Consumer setup (documented in `moo-app/README.md`)

1. Add a static `public/blank.html` (no scripts needed — the silent iframe returns the response in its URL hash, which MSAL reads directly).
2. Register `<origin>/blank.html` as a redirect URI on the Azure AD app registration.
3. Pass it to `MooApp`:
   ```tsx
   <MooApp silentRedirectUri={`${window.location.origin}/blank.html`} ... />
   ```

Default is unset → **no behavioural change** for consumers who don't opt in.

## Verification

- `tsc` (TS7) on moo-app: clean.
- `vite build` (moo-app): succeeds incl. `.d.ts` generation.
- Tests: full moo-app suite **304 passed**, including two new `HttpClientProvider` cases asserting the silent `redirectUri` is applied when configured and omitted when not, plus the `msgraph` photo-logging cases. (Also fixed a pre-existing inert mock path in `HttpClientProvider.test.tsx` — `../login/msal` → `../../login/msal` — so module mocks actually apply.)

## Limitations

Full runtime reproduction requires a consuming app (MooBank) + live Azure AD tenant, which was not run here — verified via type-check, build, unit tests, and MSAL source/doc reasoning.

The browser sandbox warning ("allow-scripts + allow-same-origin") is MSAL-internal, not configurable, and harmless — intentionally left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
