### PR TITLE
Fix ComboBox search debounce, creatable matching, and accessibility

### DIFF
--- a/moo-ds/src/components/comboBox/ComboBoxInput.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxInput.tsx
@@ -4,7 +4,7 @@ import { useInnerRef } from "../../hooks";
 
 export const ComboBoxInput = ({ placeholder, ...props }: ComboBoxInputProps) => {
 
-    const { createLabel, creatable, allItems, labelField, search, setItems, selectedItems, newItem, setNewItem, show, showInput, text, setText, setShow, ref } = useComboBox();
+    const { createLabel, creatable, allItems, labelField, search, setItems, selectedItems, newItem, setNewItem, show, showInput, text, setText, setShow, ref, listId } = useComboBox();
 
     // Debounce the actual search execution. Previously `useDebounce(search, 300)`
     // debounced the function *value* (a stable reference), so the search ran
@@ -42,6 +42,9 @@ export const ComboBoxInput = ({ placeholder, ...props }: ComboBoxInputProps) => 
 
     const keyUp: React.KeyboardEventHandler<any> = (e) => {
         if (e.key === "Escape") {
+            // Cancel any pending debounced search so it can't reopen/repopulate
+            // the list after the user dismisses it.
+            runSearch.cancel();
             setShow(false);
             setText("");
             setItems(allItems);
@@ -53,7 +56,7 @@ export const ComboBoxInput = ({ placeholder, ...props }: ComboBoxInputProps) => 
     const innerRef = useInnerRef<HTMLInputElement>(ref);
 
     return (
-        <input type="text" ref={innerRef} hidden={!inputVisible} placeholder={selectedItems?.length == 0 && !props.readonly ? placeholder : ""} onChange={onChange} onKeyUp={keyUp} value={text} tabIndex={props.tabIndex} autoCapitalize="off" autoComplete="off" autoCorrect="off" spellCheck={false} role="combobox" aria-expanded={!!show} aria-controls="cb-listbox" />
+        <input type="text" ref={innerRef} hidden={!inputVisible} placeholder={selectedItems?.length == 0 && !props.readonly ? placeholder : ""} onChange={onChange} onKeyUp={keyUp} value={text} tabIndex={props.tabIndex} autoCapitalize="off" autoComplete="off" autoCorrect="off" spellCheck={false} role="combobox" aria-expanded={!!show} aria-controls={listId} />
     );
 }
 

--- a/moo-ds/src/components/comboBox/ComboBoxInput.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxInput.tsx
@@ -1,28 +1,36 @@
 import { useComboBox } from "./ComboBoxProvider";
-import { useDebounce } from "use-debounce";
+import { useDebouncedCallback } from "use-debounce";
 import { useInnerRef } from "../../hooks";
 
 export const ComboBoxInput = ({ placeholder, ...props }: ComboBoxInputProps) => {
 
-    const { createLabel, creatable, allItems, items, labelField, search, setItems, selectedItems, newItem, setNewItem, showInput, text, setText, setShow, ref } = useComboBox();
+    const { createLabel, creatable, allItems, labelField, search, setItems, selectedItems, newItem, setNewItem, show, showInput, text, setText, setShow, ref } = useComboBox();
 
-    const [debouncedSearch] = useDebounce(search, 300);
+    // Debounce the actual search execution. Previously `useDebounce(search, 300)`
+    // debounced the function *value* (a stable reference), so the search ran
+    // synchronously on every keystroke with no debounce at all.
+    const runSearch = useDebouncedCallback((value: string) => {
+        if (!search) return;
+        setItems(search(value));
+        setShow(true);
+    }, 300);
 
     const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 
-        setText(e.currentTarget.value);
+        const value = e.currentTarget.value;
+        setText(value);
 
         if (search) {
-            setItems(debouncedSearch(e.currentTarget.value));
+            runSearch(value);
         }
         else {
-            const tempItems = allItems.filter((i) => labelField(i).toString().toLowerCase().indexOf(e.currentTarget.value.toLowerCase()) > -1);
+            const tempItems = allItems.filter((i) => labelField(i).toString().toLowerCase().indexOf(value.toLowerCase()) > -1);
 
-            if (creatable && !allItems.some((i) => labelField(i).toString() === e.currentTarget.value.toLowerCase())) {
+            if (creatable && !allItems.some((i) => labelField(i).toString().toLowerCase() === value.toLowerCase())) {
 
                 const addItem = newItem ? newItem : {};
 
-                addItem.label = createLabel(e.currentTarget.value);
+                addItem.label = createLabel(value);
 
                 setNewItem(addItem);
             }
@@ -40,19 +48,12 @@ export const ComboBoxInput = ({ placeholder, ...props }: ComboBoxInputProps) => 
         }
     }
 
-    const show = selectedItems?.length === 0 || !!showInput;
+    const inputVisible = selectedItems?.length === 0 || !!showInput;
 
     const innerRef = useInnerRef<HTMLInputElement>(ref);
 
-    /*useLayoutEffect(() => {
-        if (!props.readonly) {
-            innerRef.current.focus();
-        }
-    }, [props.readonly, innerRef]);*/
-
-
     return (
-        <input type="text" ref={innerRef} hidden={!show} placeholder={selectedItems?.length == 0 && !props.readonly ? placeholder : ""} onChange={onChange} onKeyUp={keyUp} value={text} tabIndex={props.tabIndex} autoCapitalize="off" autoComplete="off" autoCorrect="off" spellCheck={false} role="combobox" aria-expanded={items?.length > 0} />
+        <input type="text" ref={innerRef} hidden={!inputVisible} placeholder={selectedItems?.length == 0 && !props.readonly ? placeholder : ""} onChange={onChange} onKeyUp={keyUp} value={text} tabIndex={props.tabIndex} autoCapitalize="off" autoComplete="off" autoCorrect="off" spellCheck={false} role="combobox" aria-expanded={!!show} aria-controls="cb-listbox" />
     );
 }
 

--- a/moo-ds/src/components/comboBox/ComboBoxItem.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxItem.tsx
@@ -4,16 +4,28 @@ export const ComobBoxItem = <T,>(props: ComboBoxItemProps<T>) => {
 
     const { labelField } = useComboBox();
 
+    const select = () => {
+        props.onSelected(props.item);
+    }
+
     const click = (e: React.MouseEvent<HTMLLIElement>) => {
         e.preventDefault();
         e.stopPropagation();
 
-        props.onSelected(props.item);
+        select();
+    }
+
+    const keyDown = (e: React.KeyboardEvent<HTMLLIElement>) => {
+        if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            e.stopPropagation();
+            select();
+        }
     }
 
     if (props.item === undefined) return null;
 
-    return (<li onClick={click} tabIndex={2}>{props.label ?? labelField(props.item)}</li>);
+    return (<li role="option" onClick={click} onKeyDown={keyDown} tabIndex={-1}>{props.label ?? labelField(props.item)}</li>);
 }
 
 ComobBoxItem.displayName = "ComboBoxItem";

--- a/moo-ds/src/components/comboBox/ComboBoxItem.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxItem.tsx
@@ -25,7 +25,9 @@ export const ComobBoxItem = <T,>(props: ComboBoxItemProps<T>) => {
 
     if (props.item === undefined) return null;
 
-    return (<li role="option" onClick={click} onKeyDown={keyDown} tabIndex={-1}>{props.label ?? labelField(props.item)}</li>);
+    // tabIndex 0 keeps options reachable by keyboard (Tab from the input) so the
+    // Enter/Space handler is usable, without the positive-tabIndex anti-pattern.
+    return (<li role="option" onClick={click} onKeyDown={keyDown} tabIndex={0}>{props.label ?? labelField(props.item)}</li>);
 }
 
 ComobBoxItem.displayName = "ComboBoxItem";

--- a/moo-ds/src/components/comboBox/ComboBoxList.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxList.tsx
@@ -33,7 +33,7 @@ export const ComboBoxList = () => {
     }
 
     return (
-        <ol className="cb-list">
+        <ol className="cb-list" id="cb-listbox" role="listbox">
             {items.map((i) =>
                 <ComobBoxItem key={valueField(i)} onSelected={onItemSelected} item={i} />
             )}

--- a/moo-ds/src/components/comboBox/ComboBoxList.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxList.tsx
@@ -3,7 +3,7 @@ import { useComboBox } from "./ComboBoxProvider";
 
 export const ComboBoxList = () => {
 
-    const { creatable, items, multiSelect, onAdd, onChange, onCreate, show, setShow, newItem, selectedItems, setSelectedItems, setText, text, valueField } = useComboBox();
+    const { creatable, items, multiSelect, onAdd, onChange, onCreate, show, setShow, newItem, selectedItems, setSelectedItems, setText, text, valueField, listId } = useComboBox();
 
     if (!show) return null;
 
@@ -33,7 +33,7 @@ export const ComboBoxList = () => {
     }
 
     return (
-        <ol className="cb-list" id="cb-listbox" role="listbox">
+        <ol className="cb-list" id={listId} role="listbox">
             {items.map((i) =>
                 <ComobBoxItem key={valueField(i)} onSelected={onItemSelected} item={i} />
             )}
@@ -41,7 +41,7 @@ export const ComboBoxList = () => {
                 <ComobBoxItem onSelected={onItemCreated} item={newItem} label={newItem.label} />
             }
             {!creatable && items.length === 0 &&
-                <li className="no-results">No results found</li>
+                <li className="no-results" role="presentation">No results found</li>
             }
         </ol>
     );

--- a/moo-ds/src/components/comboBox/ComboBoxProvider.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxProvider.tsx
@@ -1,5 +1,5 @@
 import { type RefProps } from "../../models";
-import React, { createContext, type ReactNode, useContext, useEffect, useMemo, useState } from "react";
+import React, { createContext, type ReactNode, useContext, useEffect, useId, useMemo, useState } from "react";
 
 export const ComboBoxContext = createContext<ComboBoxOptions | undefined>(undefined);
 
@@ -11,6 +11,10 @@ export const ComboBoxProvider = <T,>(props: React.PropsWithChildren<ComboBoxProv
     const [newItem, setNewItem] = useState(null as any);
     const [show, setShow] = useState(false);
     const [showInput, setShowInput] = useState(false);
+
+    // Per-instance listbox id so multiple ComboBoxes on a page don't share a
+    // duplicated aria-controls/id relationship.
+    const listId = useId();
 
     const allItems = useMemo(() => {
         if (!props.multiSelect) return props.items ? props.items : []
@@ -48,7 +52,7 @@ export const ComboBoxProvider = <T,>(props: React.PropsWithChildren<ComboBoxProv
     const { clearable, creatable, multiSelect, readonly, labelField, valueField, colourField, onAdd, onRemove, onChange, onCreate, createLabel, search, ref } = props;
 
     return (
-        <ComboBoxContext value={{ selectedItems, setSelectedItems, text, setText, items, setItems, newItem, setNewItem, show, setShow, showInput, setShowInput, clear, clearable, creatable, multiSelect, readonly, labelField, valueField, colourField, onAdd, onRemove, onChange, onCreate, createLabel, search, allItems, ref }}>
+        <ComboBoxContext value={{ selectedItems, setSelectedItems, text, setText, items, setItems, newItem, setNewItem, show, setShow, showInput, setShowInput, clear, clearable, creatable, multiSelect, readonly, labelField, valueField, colourField, onAdd, onRemove, onChange, onCreate, createLabel, search, allItems, ref, listId }}>
             {props.children}
         </ComboBoxContext>
     );
@@ -96,6 +100,7 @@ export interface ComboBoxOptions {
     search?: (input: string) => any[];
     allItems?: any[];
     ref: React.Ref<HTMLInputElement>;
+    listId: string;
 }
 
 export interface ComboBoxProps<TItem> extends RefProps<HTMLInputElement> {

--- a/moo-ds/src/components/comboBox/__tests__/ComboBoxInput.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBoxInput.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ComboBoxInput } from '../ComboBoxInput';
 import { ComboBoxProvider } from '../ComboBoxProvider';
@@ -111,7 +111,11 @@ describe('ComboBoxInput', () => {
 
         expect(search).not.toHaveBeenCalled();
 
-        vi.advanceTimersByTime(300);
+        // Wrap in act() so React flushes the state updates the debounced
+        // callback schedules before we assert.
+        act(() => {
+          vi.advanceTimersByTime(300);
+        });
 
         expect(search).toHaveBeenCalledTimes(1);
         expect(search).toHaveBeenCalledWith('app');
@@ -127,7 +131,9 @@ describe('ComboBoxInput', () => {
 
       const input = screen.getByRole('combobox');
       expect(input).toHaveAttribute('aria-expanded');
-      expect(input).toHaveAttribute('aria-controls', 'cb-listbox');
+      // aria-controls is a per-instance generated id (React useId), not a
+      // shared hard-coded value.
+      expect(input.getAttribute('aria-controls')).toBeTruthy();
     });
   });
 

--- a/moo-ds/src/components/comboBox/__tests__/ComboBoxInput.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBoxInput.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ComboBoxInput } from '../ComboBoxInput';
 import { ComboBoxProvider } from '../ComboBoxProvider';
@@ -92,6 +92,42 @@ describe('ComboBoxInput', () => {
 
       // The filtering happens in the context, we verify the input value
       expect(screen.getByRole('combobox')).toHaveValue('App');
+    });
+
+    it('debounces the search callback (runs once after the delay, not per keystroke)', () => {
+      vi.useFakeTimers();
+      try {
+        const search = vi.fn().mockReturnValue([]);
+        render(
+          <ComboBoxProvider {...defaultProps} search={search}>
+            <ComboBoxInput placeholder="Search..." readonly={false} />
+          </ComboBoxProvider>
+        );
+
+        const input = screen.getByRole('combobox');
+        fireEvent.change(input, { target: { value: 'a' } });
+        fireEvent.change(input, { target: { value: 'ap' } });
+        fireEvent.change(input, { target: { value: 'app' } });
+
+        expect(search).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(300);
+
+        expect(search).toHaveBeenCalledTimes(1);
+        expect(search).toHaveBeenCalledWith('app');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe('accessibility', () => {
+    it('exposes aria-expanded and aria-controls on the combobox', () => {
+      renderWithProvider();
+
+      const input = screen.getByRole('combobox');
+      expect(input).toHaveAttribute('aria-expanded');
+      expect(input).toHaveAttribute('aria-controls', 'cb-listbox');
     });
   });
 

--- a/moo-ds/src/components/comboBox/__tests__/ComboBoxItem.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBoxItem.test.tsx
@@ -38,7 +38,7 @@ describe('ComboBoxItem', () => {
       const onSelected = vi.fn();
       renderWithProvider({ item: items[0], onSelected });
 
-      expect(screen.getByRole('listitem')).toBeInTheDocument();
+      expect(screen.getByRole('option')).toBeInTheDocument();
     });
 
     it('renders item label from labelField', () => {
@@ -95,11 +95,21 @@ describe('ComboBoxItem', () => {
   });
 
   describe('accessibility', () => {
-    it('has tabIndex', () => {
+    it('has the option role and is removed from the positive tab order', () => {
       const onSelected = vi.fn();
       renderWithProvider({ item: items[0], onSelected });
 
-      expect(screen.getByRole('listitem')).toHaveAttribute('tabindex', '2');
+      const option = screen.getByRole('option');
+      expect(option).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('selects on Enter key', () => {
+      const onSelected = vi.fn();
+      renderWithProvider({ item: items[0], onSelected });
+
+      fireEvent.keyDown(screen.getByRole('option'), { key: 'Enter' });
+
+      expect(onSelected).toHaveBeenCalledWith(items[0]);
     });
   });
 

--- a/moo-ds/src/components/comboBox/__tests__/ComboBoxItem.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBoxItem.test.tsx
@@ -100,7 +100,7 @@ describe('ComboBoxItem', () => {
       renderWithProvider({ item: items[0], onSelected });
 
       const option = screen.getByRole('option');
-      expect(option).toHaveAttribute('tabindex', '-1');
+      expect(option).toHaveAttribute('tabindex', '0');
     });
 
     it('selects on Enter key', () => {

--- a/moo-ds/src/components/form/FormComboBox.tsx
+++ b/moo-ds/src/components/form/FormComboBox.tsx
@@ -17,7 +17,6 @@ export const FormComboBox = <T,>({ id, ref, ...rest }: Omit<ComboBoxProps<T>, "s
                     rest.items?.filter(i => field.value === rest.valueField(i));
 
                 const onChange = (items: T[]) => {
-                    console.log("onChange", items);
                     if (rest.multiSelect) {
                         field.onChange(items?.map(i => rest.valueField(i)))
                     } else {


### PR DESCRIPTION
Part 2 of the review-remediation series. Non-breaking ComboBox correctness + a11y fixes.

## Fixes
- **Search debounce (bug)** — `useDebounce(search, 300)` debounced the function *value*, not the call, so search ran synchronously on every keystroke. Now uses `useDebouncedCallback`.
- **Creatable matching (bug)** — the "does this item already exist?" check compared an un-lowercased label to a lowercased input, so mixed-case items (e.g. `Apple`) never matched and a bogus "create new" option appeared. Both sides now lowercased.
- **A11y** — `aria-expanded` now reflects the listbox open state (was item count); added `aria-controls`; `ComboBoxItem` gains `role="option"` + keyboard selection and drops the positive `tabIndex={2}`; `ComboBoxList` gains `role="listbox"` + id.
- **Cleanup** — removed a leftover `console.log` in `FormComboBox` and a dead commented-out focus effect in `ComboBoxInput`.

## Deferred (documented in commit)
Provider context-value memoization (P2/P3) was evaluated and intentionally deferred — inline field-accessor props bust any `useMemo`, and the `JSON.stringify` deps are a deliberate deep-compare. Higher-value memoization lands on the app-wide providers in a later PR.

## Verification
- `moo-ds` type-check clean
- ComboBox + FormComboBox suites pass (119 tests); regression tests added for debounce and a11y attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)