### PR TITLE
Harden moo-ds hooks and date/string utils

### DIFF
--- a/moo-ds/src/hooks/__tests__/useClickAway.test.tsx
+++ b/moo-ds/src/hooks/__tests__/useClickAway.test.tsx
@@ -137,6 +137,44 @@ describe('useClickAway', () => {
     });
   });
 
+  describe('effect stability', () => {
+    it('does not re-subscribe listeners on re-render', () => {
+      const setShow = vi.fn();
+      const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
+
+      const { rerender } = render(<TestComponent setShow={setShow} />);
+
+      const initialCalls = addEventListenerSpy.mock.calls.filter(
+        (call) => call[0] === 'mousedown'
+      ).length;
+
+      rerender(<TestComponent setShow={setShow} />);
+
+      const afterRerenderCalls = addEventListenerSpy.mock.calls.filter(
+        (call) => call[0] === 'mousedown'
+      ).length;
+
+      // The ref is stable across renders, so the effect must not re-run.
+      expect(afterRerenderCalls).toBe(initialCalls);
+
+      addEventListenerSpy.mockRestore();
+    });
+
+    it('still calls the latest setShow after a re-render', () => {
+      const firstSetShow = vi.fn();
+      const secondSetShow = vi.fn();
+
+      const { rerender } = render(<TestComponent setShow={firstSetShow} />);
+
+      rerender(<TestComponent setShow={secondSetShow} />);
+
+      fireEvent.mouseDown(screen.getByTestId('outside'));
+
+      expect(secondSetShow).toHaveBeenCalledWith(false);
+      expect(firstSetShow).not.toHaveBeenCalled();
+    });
+  });
+
   describe('document clicks', () => {
     it('triggers on document body click', () => {
       const setShow = vi.fn();

--- a/moo-ds/src/hooks/__tests__/useInnerRef.test.tsx
+++ b/moo-ds/src/hooks/__tests__/useInnerRef.test.tsx
@@ -32,6 +32,24 @@ describe('useInnerRef', () => {
       expect(callbackRef).toHaveBeenCalledTimes(1);
       expect(callbackRef).toHaveBeenCalledWith(screen.getByTestId('element'));
     });
+
+    it('calls the callback ref with null on unmount', () => {
+      const callbackRef = vi.fn();
+
+      const TestComponent = () => {
+        const innerRef = useInnerRef<HTMLDivElement>(callbackRef);
+        return <div ref={innerRef} data-testid="element">Test</div>;
+      };
+
+      const { unmount } = render(<TestComponent />);
+
+      callbackRef.mockClear();
+
+      unmount();
+
+      // The consumer's ref must be cleared so it doesn't retain a stale node.
+      expect(callbackRef).toHaveBeenCalledWith(null);
+    });
   });
 
   describe('with ref object', () => {

--- a/moo-ds/src/hooks/__tests__/useStorage.test.ts
+++ b/moo-ds/src/hooks/__tests__/useStorage.test.ts
@@ -184,5 +184,96 @@ describe('useStorage', () => {
       expect(mockStorage.setItem).toHaveBeenCalledWith('key1', JSON.stringify('updated1'));
       expect(result2.current[0]).toBe('value2');
     });
+
+    it('re-reads from storage when the key changes', () => {
+      vi.mocked(mockStorage.getItem).mockImplementation((k: string) =>
+        k === 'key2' ? JSON.stringify('value2') : null
+      );
+
+      const { result, rerender } = renderHook(
+        ({ key }) => useStorage(mockStorage, key, 'fallback'),
+        { initialProps: { key: 'key1' } }
+      );
+
+      expect(result.current[0]).toBe('fallback');
+
+      rerender({ key: 'key2' });
+
+      expect(result.current[0]).toBe('value2');
+    });
+  });
+
+  describe('corrupt values', () => {
+    it('falls back to the initial value when the stored value is not valid JSON', () => {
+      vi.mocked(mockStorage.getItem).mockReturnValue('this-is-not-json');
+
+      const { result } = renderHook(() =>
+        useStorage(mockStorage, 'testKey', 'fallback')
+      );
+
+      // A corrupt/legacy value must not crash the tree.
+      expect(result.current[0]).toBe('fallback');
+    });
+  });
+
+  describe('cross-tab sync', () => {
+    it('updates state when a storage event for the same key fires', () => {
+      vi.mocked(mockStorage.getItem).mockReturnValue(JSON.stringify('initial'));
+
+      const { result } = renderHook(() =>
+        useStorage(mockStorage, 'testKey', 'initial')
+      );
+
+      expect(result.current[0]).toBe('initial');
+
+      act(() => {
+        window.dispatchEvent(
+          new StorageEvent('storage', {
+            key: 'testKey',
+            newValue: JSON.stringify('fromOtherTab'),
+          })
+        );
+      });
+
+      expect(result.current[0]).toBe('fromOtherTab');
+    });
+
+    it('ignores storage events for a different key', () => {
+      vi.mocked(mockStorage.getItem).mockReturnValue(JSON.stringify('initial'));
+
+      const { result } = renderHook(() =>
+        useStorage(mockStorage, 'testKey', 'initial')
+      );
+
+      act(() => {
+        window.dispatchEvent(
+          new StorageEvent('storage', {
+            key: 'otherKey',
+            newValue: JSON.stringify('nope'),
+          })
+        );
+      });
+
+      expect(result.current[0]).toBe('initial');
+    });
+
+    it('falls back to the initial value when a storage event carries corrupt JSON', () => {
+      vi.mocked(mockStorage.getItem).mockReturnValue(JSON.stringify('initial'));
+
+      const { result } = renderHook(() =>
+        useStorage(mockStorage, 'testKey', 'fallback')
+      );
+
+      act(() => {
+        window.dispatchEvent(
+          new StorageEvent('storage', {
+            key: 'testKey',
+            newValue: 'not-json',
+          })
+        );
+      });
+
+      expect(result.current[0]).toBe('fallback');
+    });
   });
 });

--- a/moo-ds/src/hooks/__tests__/useStorage.test.ts
+++ b/moo-ds/src/hooks/__tests__/useStorage.test.ts
@@ -257,6 +257,27 @@ describe('useStorage', () => {
       expect(result.current[0]).toBe('initial');
     });
 
+    it('ignores storage events from a different storage area', () => {
+      vi.mocked(mockStorage.getItem).mockReturnValue(JSON.stringify('initial'));
+
+      const { result } = renderHook(() =>
+        useStorage(mockStorage, 'testKey', 'initial')
+      );
+
+      act(() => {
+        const event = new StorageEvent('storage', {
+          key: 'testKey',
+          newValue: JSON.stringify('fromOtherArea'),
+        });
+        // jsdom rejects a foreign storageArea in the constructor, so attach it
+        // afterwards. Any object !== the hook's storage should be ignored.
+        Object.defineProperty(event, 'storageArea', { value: window.sessionStorage });
+        window.dispatchEvent(event);
+      });
+
+      expect(result.current[0]).toBe('initial');
+    });
+
     it('falls back to the initial value when a storage event carries corrupt JSON', () => {
       vi.mocked(mockStorage.getItem).mockReturnValue(JSON.stringify('initial'));
 

--- a/moo-ds/src/hooks/__tests__/useUpdatingState.test.ts
+++ b/moo-ds/src/hooks/__tests__/useUpdatingState.test.ts
@@ -130,6 +130,45 @@ describe('useUpdatingState', () => {
       expect(result.current[0]).toBe('newProp');
     });
 
+    it('does not invoke a function value as a state updater with previous state', () => {
+      // A function value is a lazy initialiser: it must be called with no
+      // arguments, never as a React updater that receives the previous state.
+      const makeValue = (label: string) =>
+        ((...args: unknown[]) => `${label}:${args.length}`) as unknown as () => string;
+
+      const { result, rerender } = renderHook(
+        ({ value }) => useUpdatingState(value),
+        { initialProps: { value: makeValue('a') } }
+      );
+
+      expect(result.current[0]).toBe('a:0');
+
+      rerender({ value: makeValue('b') });
+
+      // Still resolved with zero args - not called with (prevState).
+      expect(result.current[0]).toBe('b:0');
+    });
+
+    it('preserves local state when the same function value reference is passed', () => {
+      const fn = () => 'computed';
+
+      const { result, rerender } = renderHook(
+        ({ value }) => useUpdatingState(value),
+        { initialProps: { value: fn } }
+      );
+
+      act(() => {
+        result.current[1]('local');
+      });
+
+      expect(result.current[0]).toBe('local');
+
+      // Same reference - no reset should occur.
+      rerender({ value: fn });
+
+      expect(result.current[0]).toBe('local');
+    });
+
     it('preserves local state when prop reference is same', () => {
       // The useEffect has [value] as dependency, so it only runs when
       // the reference changes. Same reference = effect doesn't run.

--- a/moo-ds/src/hooks/clickAway.ts
+++ b/moo-ds/src/hooks/clickAway.ts
@@ -1,20 +1,27 @@
-import React, { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
-export const useClickAway = (setShow: (value: boolean) => void, ref: React.RefObject<any>, onClickAway?: () => void) => {
+export const useClickAway = (setShow: (value: boolean) => void, ref: React.RefObject<HTMLElement | null | undefined>, onClickAway?: () => void) => {
 
-    function handleClickOutside(event: Event) {
-        if (ref.current && !ref.current.contains(event.target)) {
-            onClickAway?.();
-            setShow?.(false);
-        }
-    }
+    // Keep the latest callbacks in refs so the effect can subscribe once and
+    // still call the current handlers without re-subscribing every render.
+    const setShowRef = useRef(setShow);
+    const onClickAwayRef = useRef(onClickAway);
+    setShowRef.current = setShow;
+    onClickAwayRef.current = onClickAway;
 
     useEffect(() => {
+        const handleClickOutside = (event: Event) => {
+            if (ref.current && !ref.current.contains(event.target as Node)) {
+                onClickAwayRef.current?.();
+                setShowRef.current?.(false);
+            }
+        };
+
         document.addEventListener("mousedown", handleClickOutside);
         document.addEventListener("touchstart", handleClickOutside);
         return () => {
             document.removeEventListener("mousedown", handleClickOutside);
             document.removeEventListener("touchstart", handleClickOutside);
         };
-    });
+    }, [ref]);
 }

--- a/moo-ds/src/hooks/innerRef.ts
+++ b/moo-ds/src/hooks/innerRef.ts
@@ -5,13 +5,16 @@ export const useInnerRef = <T extends HTMLElement>(ref: React.Ref<T>) => {
     const innerRef = useRef<T>(null);
 
     useEffect(() => {
-        if (!ref) return;
+        if (!ref) return undefined;
         if (typeof ref === "function") {
             ref(innerRef.current);
-        } else {
-            ref.current = innerRef.current;
+            // Clear the consumer's callback ref on unmount so it doesn't retain
+            // a stale, detached node.
+            return () => { ref(null); };
         }
-    }, [ref, innerRef]);
+        ref.current = innerRef.current;
+        return undefined;
+    }, [ref]);
 
     return innerRef;
 };

--- a/moo-ds/src/hooks/updatingState.ts
+++ b/moo-ds/src/hooks/updatingState.ts
@@ -1,11 +1,18 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 export const useUpdatingState = <T>(value: T | (() => T)): [T, React.Dispatch<React.SetStateAction<T>>] => {
 
     const [state, setState] = useState<T>(value);
 
+    // Track the last value we synced from so we only reset when it actually changes.
+    const previousValue = useRef(value);
+
     useEffect(() => {
-        setState(value);
+        if (Object.is(previousValue.current, value)) return;
+        previousValue.current = value;
+        // Resolve a function value as a lazy initialiser and store it via a
+        // functional update, so it is never invoked as a React state updater.
+        setState(() => (typeof value === "function" ? (value as () => T)() : value));
     }, [value]);
 
     return [state, setState];

--- a/moo-ds/src/hooks/useStorage.ts
+++ b/moo-ds/src/hooks/useStorage.ts
@@ -35,6 +35,9 @@ export const useStorage = <T = undefined>(storage: Storage, key: string, initial
         if (typeof window === "undefined") return undefined;
 
         const handleStorage = (event: StorageEvent) => {
+            // Ignore events from a different storage area (e.g. localStorage
+            // when this hook is backed by sessionStorage).
+            if (event.storageArea && event.storageArea !== storage) return;
             if (event.key !== key) return;
 
             if (event.newValue === null) {

--- a/moo-ds/src/hooks/useStorage.ts
+++ b/moo-ds/src/hooks/useStorage.ts
@@ -1,14 +1,59 @@
-import { type SetStateAction, useState } from "react";
+import { type SetStateAction, useEffect, useRef, useState } from "react";
 
 export const useStorage = <T = undefined>(storage: Storage, key: string, initialValue: (T | undefined) | (() => T | undefined)): [T, React.Dispatch<SetStateAction<T>>] => {
 
-    const [storedValue, setStoredValue] = useState<T>(() => {
-        const val = storage.getItem(key);
+    const readValue = (): T => {
+        // SSR-safety: no window/storage available during server render.
+        if (typeof window === "undefined") return initialValue as T;
 
-        if (!val) return initialValue;
-    
-        return JSON.parse(val);
-    });
+        try {
+            const val = storage.getItem(key);
+
+            if (!val) return initialValue as T;
+
+            return JSON.parse(val);
+        } catch {
+            // Corrupt or legacy (non-JSON) value: fall back rather than crash the tree.
+            return initialValue as T;
+        }
+    };
+
+    const [storedValue, setStoredValue] = useState<T>(readValue);
+
+    // Re-read from storage when the key changes (skip the initial mount).
+    const keyRef = useRef(key);
+    useEffect(() => {
+        if (keyRef.current === key) return;
+        keyRef.current = key;
+        // Wrap in a functional update so a function initialValue is stored, not invoked.
+        setStoredValue(() => readValue());
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [key]);
+
+    // Cross-tab synchronisation via the window storage event.
+    useEffect(() => {
+        if (typeof window === "undefined") return undefined;
+
+        const handleStorage = (event: StorageEvent) => {
+            if (event.key !== key) return;
+
+            if (event.newValue === null) {
+                setStoredValue(() => initialValue as T);
+                return;
+            }
+
+            try {
+                const parsed = JSON.parse(event.newValue) as T;
+                setStoredValue(() => parsed);
+            } catch {
+                setStoredValue(() => initialValue as T);
+            }
+        };
+
+        window.addEventListener("storage", handleStorage);
+        return () => window.removeEventListener("storage", handleStorage);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [key]);
 
     const setValue = (value: SetStateAction<T>) => {
         const valueToStore = value instanceof Function ? value(storedValue) : value;

--- a/moo-ds/src/utils/__tests__/dateHelpers.test.ts
+++ b/moo-ds/src/utils/__tests__/dateHelpers.test.ts
@@ -3,19 +3,21 @@ import { dateOnly, nextSunday, toUrl } from '../dateHelpers';
 
 describe('dateHelpers', () => {
   describe('dateOnly', () => {
+    // Note: dateOnly now zero-pads month and day (e.g. 2024-01-05). The earlier
+    // expectations (2024-1-5) encoded the pre-fix, non-padded behaviour.
     it('formats date with default separator', () => {
       const date = new Date(2024, 0, 15); // January 15, 2024
-      expect(dateOnly(date)).toBe('2024-1-15');
+      expect(dateOnly(date)).toBe('2024-01-15');
     });
 
     it('formats date with custom separator', () => {
       const date = new Date(2024, 0, 15);
-      expect(dateOnly(date, '/')).toBe('2024/1/15');
+      expect(dateOnly(date, '/')).toBe('2024/01/15');
     });
 
-    it('handles single-digit month', () => {
+    it('zero-pads single-digit month and day', () => {
       const march = new Date(2024, 2, 5); // March 5, 2024
-      expect(dateOnly(march)).toBe('2024-3-5');
+      expect(dateOnly(march)).toBe('2024-03-05');
     });
 
     it('handles double-digit month', () => {
@@ -25,7 +27,7 @@ describe('dateHelpers', () => {
 
     it('handles first day of year', () => {
       const newYear = new Date(2024, 0, 1);
-      expect(dateOnly(newYear)).toBe('2024-1-1');
+      expect(dateOnly(newYear)).toBe('2024-01-01');
     });
 
     it('handles last day of year', () => {
@@ -90,11 +92,24 @@ describe('dateHelpers', () => {
     });
 
     it('resets time to midnight', () => {
-      const date = new Date(2024, 0, 8, 14, 30, 45);
+      const date = new Date(2024, 0, 8, 14, 30, 45, 500);
       const result = nextSunday(date);
       expect(result.getHours()).toBe(0);
       expect(result.getMinutes()).toBe(0);
       expect(result.getSeconds()).toBe(0);
+      expect(result.getMilliseconds()).toBe(0);
+    });
+
+    it('does not mutate the input date', () => {
+      const input = new Date(2024, 0, 8, 14, 30, 45, 500); // Monday
+      const inputTime = input.getTime();
+      const result = nextSunday(input);
+      // Input is untouched...
+      expect(input.getTime()).toBe(inputTime);
+      expect(input.getDate()).toBe(8);
+      expect(input.getHours()).toBe(14);
+      // ...and a distinct instance was returned.
+      expect(result).not.toBe(input);
     });
 
     it('handles month boundary', () => {
@@ -119,19 +134,19 @@ describe('dateHelpers', () => {
     it('formats date for URL with / separator', () => {
       const monday = new Date(2024, 0, 8);
       const result = toUrl(monday);
-      expect(result).toBe('2024/1/14'); // Next Sunday
+      expect(result).toBe('2024/01/14'); // Next Sunday
     });
 
     it('works with Sunday input', () => {
       const sunday = new Date(2024, 0, 7);
       const result = toUrl(sunday);
-      expect(result).toBe('2024/1/7');
+      expect(result).toBe('2024/01/07');
     });
 
     it('handles month boundary in URL', () => {
       const monday = new Date(2024, 0, 29);
       const result = toUrl(monday);
-      expect(result).toBe('2024/2/4'); // February 4
+      expect(result).toBe('2024/02/04'); // February 4
     });
   });
 });

--- a/moo-ds/src/utils/dateHelpers.ts
+++ b/moo-ds/src/utils/dateHelpers.ts
@@ -1,10 +1,13 @@
-export const dateOnly = (date: Date, separator = '-'): string => `${date.getFullYear()}${separator}${date.getMonth()+1}${separator}${date.getDate()}`;
+export const dateOnly = (date: Date, separator = '-'): string => `${date.getFullYear()}${separator}${String(date.getMonth()+1).padStart(2, "0")}${separator}${String(date.getDate()).padStart(2, "0")}`;
 
 export const nextSunday = (date: Date | string): Date => {
 
     if (typeof date === "string") {
         date = new Date(Date.parse(date));
     }
+
+    // Clone so we never mutate the caller's Date instance.
+    date = new Date(date);
 
     const dayOfWeek = date.getDay();
 
@@ -15,6 +18,7 @@ export const nextSunday = (date: Date | string): Date => {
     date.setHours(0);
     date.setMinutes(0);
     date.setSeconds(0);
+    date.setMilliseconds(0);
 
     return date;
 }

--- a/moo-ds/src/utils/trimEnd.ts
+++ b/moo-ds/src/utils/trimEnd.ts
@@ -1,6 +1,6 @@
 export const trimEnd = (charsToRemove: string, string: string) => {
 
-    if (!string || !charsToRemove || charsToRemove === "") return string;
+    if (!string || !charsToRemove) return string;
 
     const length = charsToRemove.length;
 


### PR DESCRIPTION
Part 3 of the review-remediation series. Non-breaking correctness/robustness fixes in `moo-ds` hooks and utils.

## Fixes
- **dateHelpers.dateOnly** — zero-pads month/day (`2026-07-03`), fixing non-ISO, non-sortable URL path segments produced via `toUrl`.
- **dateHelpers.nextSunday** — clones its input instead of mutating the caller's `Date`, and zeros milliseconds.
- **useStorage** — guards `JSON.parse` (corrupt/legacy values fall back rather than crash the tree on mount), re-reads on `key` change, syncs across tabs via the `storage` event, and adds SSR guards.
- **useClickAway** — adds a dependency array so document listeners subscribe once (was re-subscribing every render); latest handlers read via refs; `ref` type moved off `any`.
- **useInnerRef** — clears a callback ref (`ref(null)`) on unmount so consumers don't retain a stale detached node.
- **useUpdatingState** — only resets local state when the value actually changes, and stores a function value instead of invoking it as a state updater.
- **trimEnd** — removes a redundant empty-string condition.

## Verification
- `moo-ds` type-check clean
- Full `moo-ds` suite passes: **1210 tests**. Regression tests added for every behavioural fix (padding, non-mutation, corrupt-JSON fallback, cross-tab sync, single-subscribe, callback-ref cleanup, function-value handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)