### PR TITLE
Fix moo-app API hooks and de-duplicate mutation boilerplate

### DIFF
--- a/moo-app/src/services/__tests__/processAxiosError.test.ts
+++ b/moo-app/src/services/__tests__/processAxiosError.test.ts
@@ -53,6 +53,23 @@ describe('processAxiosError', () => {
       expect(result.message).toBe('Not Found');
     });
 
+    it('returns error from statusText when data is null and does not throw', () => {
+      const error = {
+        response: {
+          data: null,
+          statusText: 'Internal Server Error',
+        },
+      } as AxiosError<any>;
+
+      let result: Error;
+      expect(() => {
+        result = processAxiosError(error);
+      }).not.toThrow();
+
+      expect(result!).toBeInstanceOf(Error);
+      expect(result!.message).toBe('Internal Server Error');
+    });
+
     it('logs the error to console', () => {
       const error = {
         response: {

--- a/moo-app/src/services/__tests__/useApiDelete.test.tsx
+++ b/moo-app/src/services/__tests__/useApiDelete.test.tsx
@@ -79,6 +79,22 @@ describe('useApiDelete', () => {
       expect(mockDelete).toHaveBeenCalledWith('/api/items/42');
     });
 
+    it('resolves to undefined (not the AxiosResponse)', async () => {
+      mockDelete.mockResolvedValue({ data: null });
+
+      const { result } = renderHook(
+        () => useApiDelete<{ id: number }>((vars) => `/api/items/${vars.id}`),
+        { wrapper: createWrapper() }
+      );
+
+      let resolved: unknown = 'sentinel';
+      await act(async () => {
+        resolved = await result.current.mutateAsync({ id: 42 });
+      });
+
+      expect(resolved).toBeUndefined();
+    });
+
     it('handles complex path variables', async () => {
       mockDelete.mockResolvedValue({ data: null });
 

--- a/moo-app/src/services/__tests__/useApiGet.test.tsx
+++ b/moo-app/src/services/__tests__/useApiGet.test.tsx
@@ -186,7 +186,7 @@ describe('useApiPagedGet', () => {
     });
 
     expect(result.current.data?.results).toEqual([{ id: 1 }, { id: 2 }]);
-    expect(result.current.data?.total).toBe('100');
+    expect(result.current.data?.total).toBe(100);
   });
 
   it('fetches paged data', async () => {

--- a/moo-app/src/services/index.ts
+++ b/moo-app/src/services/index.ts
@@ -1,6 +1,7 @@
 export * from "./msgraph";
 export * from "./types";
 export * from "./useApiGet";
+export * from "./useApiMutation";
 export * from "./useApiPut";
 export * from "./useApiPost";
 export * from "./useApiPatch";

--- a/moo-app/src/services/processAxiosError.ts
+++ b/moo-app/src/services/processAxiosError.ts
@@ -7,7 +7,7 @@ export const processAxiosError = (error: any): Error => {
 
     if (axiosError.response) {
         console.error(`API Error`, axiosError.response?.data);
-        return new Error(axiosError.response.data.detail ?? axiosError.response.data.title ?? axiosError.response.statusText);
+        return new Error(axiosError.response.data?.detail ?? axiosError.response.data?.title ?? axiosError.response.statusText);
     }
     else if (axiosError.request) {
         return new Error("No response received from server.");

--- a/moo-app/src/services/useApiDelete.ts
+++ b/moo-app/src/services/useApiDelete.ts
@@ -1,30 +1,13 @@
-import { type DefaultError, type MutationFunctionContext, useMutation, type UseMutationOptions, type UseMutationResult } from "@tanstack/react-query";
+import { type DefaultError, type UseMutationOptions, type UseMutationResult } from "@tanstack/react-query";
 import { useHttpClient } from "../providers/HttpClientProvider";
-import { processAxiosError } from "./processAxiosError";
-import { useErrorHandler } from "./errorHandler";
+import { useApiMutation } from "./useApiMutation";
 
-export const useApiDelete = <Variables>(path: (variables: Variables) => string, options?: UseMutationOptions<null, Error, Variables>): UseMutationResult<Response, DefaultError, Variables> => {
-
+export const useApiDelete = <Variables>(path: (variables: Variables) => string, options?: UseMutationOptions<void, DefaultError, Variables>): UseMutationResult<void, DefaultError, Variables> => {
     const httpClient = useHttpClient();
-    const errorHandler = useErrorHandler();
-
-    const { onError, ...otherOptions } = options ?? {};
-
-    const onErrorWrapper = (error: Error, variables: Variables, onMutateResult: unknown, context: MutationFunctionContext) => {
-        errorHandler(error);
-        onError?.(error, variables, onMutateResult, context);
-    }
-    
-    return useMutation<null, null, Variables>({
-        mutationFn: async (variables): Promise<null> => {
-            try {
-                return await httpClient.delete(path(variables));
-            }
-            catch (error: any) {
-                throw processAxiosError(error);
-            }
+    return useApiMutation<void, Variables>(
+        async (variables) => {
+            await httpClient.delete(path(variables));
         },
-        onError: onErrorWrapper,
-        ...otherOptions
-    });
+        options
+    );
 }

--- a/moo-app/src/services/useApiGet.ts
+++ b/moo-app/src/services/useApiGet.ts
@@ -12,7 +12,7 @@ export const useApiPagedGet = <T extends PagedResult<any>>(key: QueryKey, path: 
 
         return {
             results: response.data,
-            total: response.headers["x-total-count"],
+            total: Number(response.headers["x-total-count"]),
         } as T;
     }
 

--- a/moo-app/src/services/useApiMutation.ts
+++ b/moo-app/src/services/useApiMutation.ts
@@ -1,0 +1,28 @@
+import { type DefaultError, type MutationFunctionContext, useMutation, type UseMutationOptions, type UseMutationResult } from "@tanstack/react-query";
+import { processAxiosError } from "./processAxiosError";
+import { useErrorHandler } from "./errorHandler";
+
+export const useApiMutation = <Response, Variables>(
+    mutationFn: (variables: Variables) => Promise<Response>,
+    options?: UseMutationOptions<Response, DefaultError, Variables>
+): UseMutationResult<Response, DefaultError, Variables> => {
+    const errorHandler = useErrorHandler();
+    const { onError, ...otherOptions } = options ?? {};
+
+    const onErrorWrapper = (error: Error, variables: Variables, onMutateResult: unknown, context: MutationFunctionContext) => {
+        errorHandler(error);
+        onError?.(error, variables, onMutateResult, context);
+    };
+
+    return useMutation<Response, DefaultError, Variables>({
+        mutationFn: async (variables) => {
+            try {
+                return await mutationFn(variables);
+            } catch (error: any) {
+                throw processAxiosError(error);
+            }
+        },
+        onError: onErrorWrapper,
+        ...otherOptions
+    });
+};

--- a/moo-app/src/services/useApiPatch.ts
+++ b/moo-app/src/services/useApiPatch.ts
@@ -1,29 +1,11 @@
-import { type DefaultError, type MutationFunctionContext, useMutation, type UseMutationOptions, type UseMutationResult } from "@tanstack/react-query";
+import { type DefaultError, type UseMutationOptions, type UseMutationResult } from "@tanstack/react-query";
 import { useHttpClient } from "../providers/HttpClientProvider";
-import { processAxiosError } from "./processAxiosError";
-import { useErrorHandler } from "./errorHandler";
+import { useApiMutation } from "./useApiMutation";
 
 export const useApiPatch = <Response, Variables, Data = null>(path: (variables: Variables) => string, options?: UseMutationOptions<Response, DefaultError, [Variables, Data]>): UseMutationResult<Response, DefaultError, [Variables, Data]> => {
-
     const httpClient = useHttpClient();
-    const errorHandler = useErrorHandler();
-
-    const { onError, ...otherOptions } = options ?? {};
-
-    const onErrorWrapper = (error: Error, variables: [Variables, Data], onMutateResult: unknown, context: MutationFunctionContext) => {
-        errorHandler(error);
-        onError?.(error, variables, onMutateResult, context);
-    }
-    return useMutation<Response, DefaultError, [Variables, Data]>({
-        mutationFn: async ([variables, data]): Promise<Response> => {
-            try {
-                return (await httpClient.patch(path(variables), data)).data;
-            }
-            catch (error: any) {
-                throw processAxiosError(error);
-            }
-        },
-        onError: onErrorWrapper,
-        ...otherOptions
-    });
+    return useApiMutation<Response, [Variables, Data]>(
+        async ([variables, data]) => (await httpClient.patch(path(variables), data)).data,
+        options
+    );
 }

--- a/moo-app/src/services/useApiPost.ts
+++ b/moo-app/src/services/useApiPost.ts
@@ -1,87 +1,31 @@
-import { type DefaultError, type MutationFunctionContext, useMutation, type UseMutationOptions, type UseMutationResult } from "@tanstack/react-query";
+import { type DefaultError, type UseMutationOptions, type UseMutationResult } from "@tanstack/react-query";
 import { useHttpClient } from "../providers/HttpClientProvider";
-import { processAxiosError } from "./processAxiosError";
-import { useErrorHandler } from "./errorHandler";
+import { useApiMutation } from "./useApiMutation";
 
 export const useApiPost = <Response, Variables, Data = null>(path: (variables: Variables) => string, options?: UseMutationOptions<Response, DefaultError, [Variables, Data]>): UseMutationResult<Response, DefaultError, [Variables, Data]> => {
-
     const httpClient = useHttpClient();
-    const errorHandler = useErrorHandler();
-
-    const { onError, ...otherOptions } = options ?? {};
-
-    const onErrorWrapper = (error: Error, variables: [Variables, Data], onMutateResult: unknown, context: MutationFunctionContext) => {
-        errorHandler(error);
-        onError?.(error, variables, onMutateResult, context);
-    }
-
-    return useMutation<Response, DefaultError, [Variables, Data]>({
-        mutationFn: async ([variables, data]): Promise<Response> => {
-            try {
-                return (await httpClient.post(path(variables), data)).data;
-            }
-            catch (error: any) {
-                throw processAxiosError(error);
-            }
-        },
-        onError: onErrorWrapper,
-        ...otherOptions
-    });
+    return useApiMutation<Response, [Variables, Data]>(
+        async ([variables, data]) => (await httpClient.post(path(variables), data)).data,
+        options
+    );
 }
 
 export const useApiPostEmpty = <Response, Variables>(path: (variables: Variables) => string, options?: UseMutationOptions<Response, DefaultError, Variables>) => {
-
     const httpClient = useHttpClient();
-    const errorHandler = useErrorHandler();
-
-    const { onError, ...otherOptions } = options ?? {};
-
-    const onErrorWrapper = (error: Error, variables: Variables, onMutateResult: unknown, context: MutationFunctionContext) => {
-        errorHandler(error);
-        onError?.(error, variables, onMutateResult, context);
-    }
-
-    return useMutation<Response, DefaultError, Variables>({
-        mutationFn: async (variables): Promise<Response> => {
-            try {
-                return (await httpClient.post(path(variables))).data;
-            }
-            catch (error: any) {
-                throw processAxiosError(error);
-            }
-        },
-        onError: onErrorWrapper,
-        ...otherOptions
-    });
+    return useApiMutation<Response, Variables>(
+        async (variables) => (await httpClient.post(path(variables))).data,
+        options
+    );
 }
 
 export const useApiPostFile = <Variables extends { file: File }>(path: (variables: Variables) => string, options?: UseMutationOptions<null, DefaultError, Variables>) => {
-
     const httpClient = useHttpClient();
-    const errorHandler = useErrorHandler();
-
-    const { onError, ...otherOptions } = options ?? {};
-
-    const onErrorWrapper = (error: Error, variables: Variables, onMutateResult: unknown, context: MutationFunctionContext) => {
-        errorHandler(error);
-        onError?.(error, variables, onMutateResult, context);
-    }
-
-    return useMutation<null, DefaultError, Variables>({
-        mutationFn: async (variables): Promise<null> => {
-
+    return useApiMutation<null, Variables>(
+        async (variables) => {
             const formData = new FormData();
-
             formData.append("file", variables.file, variables.file.name);
-
-            try {
-                return (await httpClient.post(path(variables), formData)).data;
-            }
-            catch (error: any) {
-                throw processAxiosError(error);
-            }
+            return (await httpClient.post(path(variables), formData)).data;
         },
-        onError: onErrorWrapper,
-        ...otherOptions
-    });
+        options
+    );
 }

--- a/moo-app/src/services/useApiPut.ts
+++ b/moo-app/src/services/useApiPut.ts
@@ -1,56 +1,19 @@
-import { type DefaultError, type MutationFunctionContext, useMutation, type UseMutationOptions, type UseMutationResult } from "@tanstack/react-query";
+import { type DefaultError, type UseMutationOptions, type UseMutationResult } from "@tanstack/react-query";
 import { useHttpClient } from "../providers/HttpClientProvider";
-import { processAxiosError } from "./processAxiosError";
-import { useErrorHandler } from "./errorHandler";
+import { useApiMutation } from "./useApiMutation";
 
 export const useApiPut = <Response, Variables, Data = null>(path: (variables: Variables) => string, options?: UseMutationOptions<Response, DefaultError, [Variables, Data]>): UseMutationResult<Response, DefaultError, [Variables, Data]> => {
-
     const httpClient = useHttpClient();
-    const errorHandler = useErrorHandler();
-
-    const { onError, ...otherOptions } = options ?? {};
-
-    const onErrorWrapper = (error: Error, variables: [Variables, Data], onMutateResult: unknown, context: MutationFunctionContext) => {
-        errorHandler(error);
-        onError?.(error, variables, onMutateResult, context);
-    }
-
-    return useMutation<Response, null,[Variables, Data]>({
-        mutationFn: async ([variables, data]): Promise<Response> => {
-            try {
-                return (await httpClient.put(path(variables), data)).data;
-            }
-            catch (error: any) {
-                throw processAxiosError(error);
-            }
-        },
-        onError: onErrorWrapper,
-        ...otherOptions
-    });
+    return useApiMutation<Response, [Variables, Data]>(
+        async ([variables, data]) => (await httpClient.put(path(variables), data)).data,
+        options
+    );
 }
 
 export const useApiPutEmpty = <Response, Variables>(path: (variables: Variables) => string, options?: UseMutationOptions<Response, DefaultError, Variables>) => {
-
     const httpClient = useHttpClient();
-    const errorHandler = useErrorHandler();
-
-    const { onError, ...otherOptions } = options ?? {};
-
-    const onErrorWrapper = (error: Error, variables: Variables, onMutateResult: unknown, context: MutationFunctionContext) => {
-        errorHandler(error);
-        onError?.(error, variables, onMutateResult, context);
-    }
-
-    return useMutation<Response, null,Variables>({
-        mutationFn: async (variables): Promise<Response> => {
-            try {
-                return (await httpClient.put(path(variables))).data;
-            }
-            catch (error: any) {
-                throw processAxiosError(error);
-            }
-        },
-        onError: onErrorWrapper,
-        ...otherOptions
-    });
+    return useApiMutation<Response, Variables>(
+        async (variables) => (await httpClient.put(path(variables))).data,
+        options
+    );
 }


### PR DESCRIPTION
Part 5 of the review-remediation series. Non-breaking fixes + a de-duplication refactor in `moo-app/src/services`.

## Fixes
- **useApiDelete (bug)** — returned the whole `AxiosResponse` while declared to resolve `null`, and its type referenced the DOM `Response`. Now resolves `void` with correct typing.
- **processAxiosError (bug)** — optional-chains the response body so a null/non-JSON error payload no longer throws a `TypeError` inside the error handler (masking the real error).
- **useApiPagedGet (bug)** — coerces the `x-total-count` header with `Number(...)` (was a string cast into the numeric `total`).
- **useApiPut / useApiPutEmpty (type)** — error type is `DefaultError`, not `null` (now consistent with Post/Patch).

## Refactor
Extracts a shared **`useApiMutation`** helper and routes Post/Put/Patch/Delete — plus the Empty/File variants — through it, removing 7 copies of the `onError` + `try/catch → processAxiosError` boilerplate. All public signatures are byte-identical (except the deliberate `useApiDelete` type correction).

## Verification
- `moo-app` type-check clean
- Full `moo-app` suite passes: **301 tests**. Regression tests added for the null-body error path and the delete resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)