### PR TITLE
De-duplicate moo-app model types against moo-ds

### DIFF
--- a/moo-app/src/models/App.ts
+++ b/moo-app/src/models/App.ts
@@ -1,5 +1,3 @@
-export interface AppOptions {
-    name: string;
-    version: string;
-    copyrightYear?: number;
-}
+// Re-exported from moo-ds so there is a single canonical AppOptions type
+// rather than a structurally-identical duplicate that can silently diverge.
+export type { AppOptions } from "@andrewmclachlan/moo-ds";

--- a/moo-app/src/models/Layout.ts
+++ b/moo-app/src/models/Layout.ts
@@ -1,23 +1,3 @@
-import { type ReactNode } from "react";
-import { type NavItem } from "@andrewmclachlan/moo-ds";
-
-export type size = "small" | "default";
-
-export interface LayoutOptions {
-    size: size;
-}
-
-export interface LayoutContext extends LayoutOptions {
-    photo?: string;
-    breadcrumbs?: NavItem[];
-    setBreadcrumbs?: (items: NavItem[]) => void;
-    secondaryNav?: (NavItem|ReactNode)[];
-    setSecondaryNav?: (items: (NavItem|ReactNode)[]) => void;
-    actions?: ReactNode[];
-    setActions?: (items: ReactNode[]) => void;
-    showSidebar?: boolean;
-    setShowSidebar?: (show: boolean) => void;
-
-    sidebarCollapsed?: boolean;
-    setSidebarCollapsed?: (show: boolean) => void;
-}
+// Re-exported from moo-ds so there is a single canonical set of layout types
+// rather than structurally-identical duplicates that can silently diverge.
+export type { LayoutOptions, LayoutContext, size } from "@andrewmclachlan/moo-ds";


### PR DESCRIPTION
Part 8 of the review-remediation series (architecture / boundary hygiene, Milestone 2.1).

`moo-app/src/models/App.ts` and `Layout.ts` were byte-identical copies of the moo-ds definitions (`AppOptions`, `LayoutOptions`, `LayoutContext`, `size`). Both packages re-exported them, so the public surface carried two structurally-identical-but-distinct copies of each type that could silently diverge over time.

They now re-export from `@andrewmclachlan/moo-ds`, unifying the type identity. Because the shapes are identical, this is **not observably breaking** for consumers.

## Deferred
The parallel `useErrorHandler` de-duplication (moo-app's copy → re-export moo-ds's) was attempted but reverted: several moo-app tests partially-mock `@andrewmclachlan/moo-ds` (providing only `useMessages`), so re-exporting `useErrorHandler` through the mocked package resolves to `undefined`. Fixing it means updating brittle test mocks that overlap other in-flight PRs; deferred as low-value (the duplicate is byte-identical with no runtime cost).

## Verification
- `moo-app` type-check clean
- Full `moo-app` suite passes: **299 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)