### PR TITLE
Remove internal addMsalInterceptor from moo-app public API

### DIFF
--- a/moo-app/src/providers/index.ts
+++ b/moo-app/src/providers/index.ts
@@ -1,3 +1,7 @@
 export * from "./AppProvider";
-export * from "./HttpClientProvider";
+// addMsalInterceptor is intentionally NOT re-exported: it is internal glue
+// (used by the Graph client in services/msgraph.ts) and not part of the public
+// API. Consumers use HttpClientProvider; createHttpClient stays public as a
+// factory for building a custom client to pass to it.
+export { HttpClientProvider, HttpClientContext, useHttpClient, createHttpClient, type HttpClientProviderProps } from "./HttpClientProvider";
 export * from "./LayoutProvider";


### PR DESCRIPTION
Part 9 of the review-remediation series (architecture / boundary hygiene, Milestone 2.2). **BREAKING (niche).**

`addMsalInterceptor` is imperative internal glue — used only by the Graph client in `services/msgraph.ts`, which imports it directly. It was leaking into the package's public API via `export * from "./HttpClientProvider"`. The providers barrel now exports `HttpClientProvider` / `useHttpClient` / `HttpClientContext` and the still-useful `createHttpClient` factory, but no longer `addMsalInterceptor`.

**Breaking:** `addMsalInterceptor` is no longer importable from `@andrewmclachlan/moo-app`. Internal and test imports (direct from `./HttpClientProvider`) are unaffected; nothing imported it via the package root.

## Scope note
The form-parts surface change (Milestone 2.4 — dropping standalone `Select`/`Label`/`Password`/`TextArea`/`Group`) was **declined**: `Password` is used standalone in demoo, and `form/Input`/`Check` are compound-only specifically to avoid colliding with the top-level `Input` component — so the current mixed surface has a defensible naming rationale rather than being arbitrary.

## Verification
- `moo-app` type-check clean
- Full `moo-app` suite passes: **299 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)