### PR TITLE
Open the theme model so consumers can register custom themes

### DIFF
--- a/moo-ds/src/components/ThemeSelector.tsx
+++ b/moo-ds/src/components/ThemeSelector.tsx
@@ -1,14 +1,13 @@
 import { useTheme } from "../providers"
-import { Themes } from "../models";
 import { ThemeSample } from "./ThemeSample";
 
 export const ThemeSelector = () => {
 
-    const { theme: currentTheme, setTheme } = useTheme();
+    const { theme: currentTheme, setTheme, themes } = useTheme();
 
     return (
         <div className="theme-selector">
-            {Themes.map((t) =>
+            {themes.map((t) =>
                 <ThemeSample key={t.name} theme={t} selected={currentTheme?.theme === t.theme} onClick={(t) => setTheme(t)} />
             )}
         </div>

--- a/moo-ds/src/components/__tests__/ThemeSelector.test.tsx
+++ b/moo-ds/src/components/__tests__/ThemeSelector.test.tsx
@@ -39,6 +39,23 @@ describe('ThemeSelector', () => {
       expect(container.querySelector('.theme-selector')).toBeInTheDocument();
     });
 
+    it('renders a custom set of themes registered on the provider', () => {
+      const customThemes = [
+        { name: 'Brand Light', theme: 'brand-light', colour: '#ffffff' },
+        { name: 'Brand Dark', theme: 'brand-dark', colour: '#000000' },
+      ];
+
+      const { container } = render(
+        <ThemeProvider themes={customThemes} defaultTheme={customThemes[0]}>
+          <ThemeSelector />
+        </ThemeProvider>
+      );
+
+      expect(screen.getByText('Brand Light')).toBeInTheDocument();
+      expect(screen.getByText('Brand Dark')).toBeInTheDocument();
+      expect(container.querySelectorAll('.theme-sample').length).toBe(customThemes.length);
+    });
+
     it('renders each theme as a theme-sample', () => {
       const { container } = renderWithProvider(<ThemeSelector />);
 

--- a/moo-ds/src/models/Theme.ts
+++ b/moo-ds/src/models/Theme.ts
@@ -2,9 +2,19 @@ export interface ThemeOptions {
     theme?: Theme;
     setTheme?: (theme?: Theme) => void;
     defaultTheme: Theme;
+    /** The registered themes (built-ins by default, or a custom list supplied to ThemeProvider). */
+    themes: Theme[];
 }
 
-export type Themes = "" | "dark" | "light" | "light red" | "dark blue";
+/** The theme identifiers shipped with the design system. */
+export type BuiltInThemes = "" | "dark" | "light" | "light red" | "dark blue";
+
+/**
+ * A theme identifier. Consumers may register additional themes with any string
+ * identifier (they are responsible for shipping the matching CSS); the built-in
+ * names are kept for editor autocomplete via the `string & {}` intersection.
+ */
+export type Themes = BuiltInThemes | (string & {});
 
 export interface Theme {
     name: string,
@@ -12,7 +22,8 @@ export interface Theme {
     colour?: string,
 };
 
-export const theme = (theme: Themes) =>  Themes.find(t => t.theme === theme);
+/** Look up a theme by identifier within a list (defaults to the built-ins). */
+export const theme = (theme: Themes, themes: Theme[] = Themes) => themes.find(t => t.theme === theme);
 
 export const Themes: Theme[] = [
     {

--- a/moo-ds/src/providers/ThemeProvider.tsx
+++ b/moo-ds/src/providers/ThemeProvider.tsx
@@ -1,33 +1,35 @@
-import React, { createContext, useEffect } from "react";
+import React, { createContext, useEffect, useMemo } from "react";
 import { useContext } from "react";
-import { type Theme, type ThemeOptions, theme } from "../models";
+import { type Theme, type ThemeOptions, theme, Themes as BuiltInThemes } from "../models";
 import { useLocalStorage } from "../hooks/localStorage";
 
 const getDefaultTheme = () => window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? theme("dark") : theme("light");
 
-export const ThemeContext = createContext<ThemeOptions>({ defaultTheme: getDefaultTheme() });
+export const ThemeContext = createContext<ThemeOptions>({ defaultTheme: getDefaultTheme(), themes: BuiltInThemes });
 
-export const ThemeProvider: React.FC<React.PropsWithChildren<ThemeProviderProps>> = ({ children, ...props }) => {
-
-    const colour = document.getElementsByName("theme-color")[0];
-    if (!colour) console.warn("No theme colour meta tag found. Theme colour will not be applied.");
+export const ThemeProvider: React.FC<React.PropsWithChildren<ThemeProviderProps>> = ({ children, themes = BuiltInThemes, ...props }) => {
 
     const defaultTheme = props.defaultTheme ?? getDefaultTheme();
 
-    const [theme, setTheme] = useLocalStorage<Theme>("theme", defaultTheme);
+    const [currentTheme, setTheme] = useLocalStorage<Theme>("theme", defaultTheme);
 
     useEffect(() => {
-        colour?.setAttribute("content", theme.colour);
-        document.body.setAttribute("class", theme.theme);
-        if (theme.theme === "") {
+        const colour = document.getElementsByName("theme-color")[0];
+        if (!colour) console.warn("No theme colour meta tag found. Theme colour will not be applied.");
+
+        if (currentTheme.colour) colour?.setAttribute("content", currentTheme.colour);
+        document.body.setAttribute("class", currentTheme.theme);
+        if (currentTheme.theme === "") {
             document.body.removeAttribute("data-theme");
         } else {
-            document.body.setAttribute("data-theme", theme.theme.startsWith("dark") ? "dark" : "light");
+            document.body.setAttribute("data-theme", currentTheme.theme.startsWith("dark") ? "dark" : "light");
         }
-    }, [theme]);
+    }, [currentTheme]);
+
+    const value = useMemo<ThemeOptions>(() => ({ theme: currentTheme, setTheme, defaultTheme, themes }), [currentTheme, setTheme, defaultTheme, themes]);
 
     return (
-        <ThemeContext.Provider value={{ theme, setTheme, defaultTheme }}>
+        <ThemeContext.Provider value={value}>
             {children}
         </ThemeContext.Provider>
     );
@@ -37,6 +39,8 @@ export const useTheme = () => useContext(ThemeContext);
 
 export interface ThemeProviderProps {
     defaultTheme?: Theme;
+    /** Register a custom set of themes. Defaults to the built-in themes. */
+    themes?: Theme[];
 }
 
 ThemeProvider.displayName = "ThemeProvider";

--- a/moo-ds/src/providers/ThemeProvider.tsx
+++ b/moo-ds/src/providers/ThemeProvider.tsx
@@ -3,13 +3,20 @@ import { useContext } from "react";
 import { type Theme, type ThemeOptions, theme, Themes as BuiltInThemes } from "../models";
 import { useLocalStorage } from "../hooks/localStorage";
 
-const getDefaultTheme = () => window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? theme("dark") : theme("light");
+// SSR-safe: window/matchMedia are only touched when available. Resolves the
+// preferred default within the supplied theme list, falling back to the first
+// entry (then a built-in) so a custom list without "dark"/"light" ids still
+// yields a valid theme.
+const getDefaultTheme = (list: Theme[] = BuiltInThemes): Theme => {
+    const prefersDark = typeof window !== "undefined" && !!window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    return (prefersDark ? theme("dark", list) : theme("light", list)) ?? list[0] ?? theme("light")!;
+};
 
 export const ThemeContext = createContext<ThemeOptions>({ defaultTheme: getDefaultTheme(), themes: BuiltInThemes });
 
 export const ThemeProvider: React.FC<React.PropsWithChildren<ThemeProviderProps>> = ({ children, themes = BuiltInThemes, ...props }) => {
 
-    const defaultTheme = props.defaultTheme ?? getDefaultTheme();
+    const defaultTheme = props.defaultTheme ?? getDefaultTheme(themes);
 
     const [currentTheme, setTheme] = useLocalStorage<Theme>("theme", defaultTheme);
 
@@ -17,7 +24,13 @@ export const ThemeProvider: React.FC<React.PropsWithChildren<ThemeProviderProps>
         const colour = document.getElementsByName("theme-color")[0];
         if (!colour) console.warn("No theme colour meta tag found. Theme colour will not be applied.");
 
-        if (currentTheme.colour) colour?.setAttribute("content", currentTheme.colour);
+        if (currentTheme.colour) {
+            colour?.setAttribute("content", currentTheme.colour);
+        } else {
+            // A theme without a colour (e.g. "System") must not keep the previous
+            // theme's colour on the browser UI.
+            colour?.removeAttribute("content");
+        }
         document.body.setAttribute("class", currentTheme.theme);
         if (currentTheme.theme === "") {
             document.body.removeAttribute("data-theme");

--- a/moo-ds/src/providers/__tests__/ThemeProvider.test.tsx
+++ b/moo-ds/src/providers/__tests__/ThemeProvider.test.tsx
@@ -245,6 +245,22 @@ describe('ThemeProvider', () => {
       expect(result.current.theme?.name).toBe('Dark cool');
     });
 
+    it('clears the theme-color meta content when switching to a theme without a colour', () => {
+      const meta = document.getElementsByName('theme-color')[0] as unknown as { removeAttribute: ReturnType<typeof vi.fn> };
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <ThemeProvider>{children}</ThemeProvider>
+      );
+
+      const { result } = renderHook(() => useTheme(), { wrapper });
+
+      // Switch to a coloured theme, then to the System ("") theme which has no colour.
+      act(() => result.current.setTheme?.(Themes.find(t => !!t.colour)));
+      meta.removeAttribute.mockClear();
+      act(() => result.current.setTheme?.(Themes.find(t => t.theme === '')));
+
+      expect(meta.removeAttribute).toHaveBeenCalledWith('content');
+    });
+
     it('can cycle through all themes', () => {
       const wrapper = ({ children }: { children: React.ReactNode }) => (
         <ThemeProvider>{children}</ThemeProvider>

--- a/moo-ds/src/setupTests.ts
+++ b/moo-ds/src/setupTests.ts
@@ -41,5 +41,5 @@ Object.defineProperty(window, 'matchMedia', {
 });
 
 // Mock document.getElementsByName for ThemeProvider
-const mockThemeColorElement = { setAttribute: vi.fn() };
+const mockThemeColorElement = { setAttribute: vi.fn(), removeAttribute: vi.fn() };
 document.getElementsByName = vi.fn().mockReturnValue([mockThemeColorElement]);


### PR DESCRIPTION
Part 10 of the review-remediation series (architecture / extensibility, Milestone 3.1). **BREAKING (minor).**

The design system's themes were a closed string union plus a hardcoded `Themes` array — a consumer could not add a brand theme without editing moo-ds source, unusual for a DS whose whole point is theming.

## Changes
- `ThemeProvider` accepts an optional **`themes`** prop (defaults to the built-ins) and exposes the list via context.
- `ThemeSelector` renders the provider's theme list instead of the hardcoded import, so custom themes appear automatically.
- The theme identifier type is widened to `BuiltInThemes | (string & {})` — any custom identifier is allowed while built-in names keep autocomplete. `theme()` takes an optional list to search.
- Folds in the deferred **ThemeProvider correctness/perf fixes**: the DOM read + `console.warn` now run inside the effect (were in the render body — unsafe under StrictMode/SSR), the theme-colour meta is only set when a colour exists, and the context value is memoized.

**Breaking:** `ThemeOptions` now includes a `themes: Theme[]` field (affects anyone constructing the context value manually — rare).

## Verification
- `moo-ds` type-check clean
- Full `moo-ds` suite passes (**1199**); added a `ThemeSelector` test rendering a custom theme set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)