### PR TITLE
Add accessibility baseline to Modal

### DIFF
--- a/moo-ds/src/components/Modal.tsx
+++ b/moo-ds/src/components/Modal.tsx
@@ -1,6 +1,8 @@
 import classNames from "classnames";
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
+
+const FOCUSABLE_SELECTOR = 'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
     show: boolean;
@@ -64,6 +66,9 @@ ModalTitle.displayName = "Modal.Title";
 
 const ModalComponent: React.FC<React.PropsWithChildren<ModalProps>> = ({ show, onHide, size, className, children, style, ...rest }) => {
 
+    const contentRef = useRef<HTMLDivElement>(null);
+    const previouslyFocused = useRef<HTMLElement | null>(null);
+
     useEffect(() => {
         if (show) {
             document.body.style.overflow = "hidden";
@@ -72,6 +77,47 @@ const ModalComponent: React.FC<React.PropsWithChildren<ModalProps>> = ({ show, o
         }
         return () => { document.body.style.overflow = ""; };
     }, [show]);
+
+    // Move focus into the dialog on open and restore it to the previously
+    // focused element on close.
+    useEffect(() => {
+        if (!show) return undefined;
+
+        previouslyFocused.current = document.activeElement as HTMLElement | null;
+        const focusables = contentRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+        (focusables && focusables.length ? focusables[0] : contentRef.current)?.focus();
+
+        return () => {
+            previouslyFocused.current?.focus?.();
+        };
+    }, [show]);
+
+    const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (!show) return;
+
+        if (e.key === "Escape") {
+            e.stopPropagation();
+            onHide?.();
+            return;
+        }
+
+        if (e.key === "Tab") {
+            const focusables = contentRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+            if (!focusables || focusables.length === 0) {
+                e.preventDefault();
+                return;
+            }
+            const first = focusables[0];
+            const last = focusables[focusables.length - 1];
+            if (e.shiftKey && document.activeElement === first) {
+                e.preventDefault();
+                last.focus();
+            } else if (!e.shiftKey && document.activeElement === last) {
+                e.preventDefault();
+                first.focus();
+            }
+        }
+    };
 
     // Inject onHide into Header children
     const enhancedChildren = React.Children.map(children, (child) => {
@@ -90,10 +136,11 @@ const ModalComponent: React.FC<React.PropsWithChildren<ModalProps>> = ({ show, o
                     className={classNames("modal", show && "show", className)}
                     tabIndex={-1}
                     style={modalStyle}
+                    onKeyDown={onKeyDown}
                     {...rest}
                 >
-                    <div className="modal-dialog">
-                        <div className="modal-content">
+                    <div className="modal-dialog" role="dialog" aria-modal="true">
+                        <div className="modal-content" ref={contentRef} tabIndex={-1}>
                             {enhancedChildren}
                         </div>
                     </div>

--- a/moo-ds/src/components/Modal.tsx
+++ b/moo-ds/src/components/Modal.tsx
@@ -64,7 +64,19 @@ const ModalTitle: React.FC<React.PropsWithChildren<ModalTitleProps>> = ({ as: Co
 
 ModalTitle.displayName = "Modal.Title";
 
-const ModalComponent: React.FC<React.PropsWithChildren<ModalProps>> = ({ show, onHide, size, className, children, style, ...rest }) => {
+const ModalComponent: React.FC<React.PropsWithChildren<ModalProps>> = ({
+    show,
+    onHide,
+    size,
+    className,
+    children,
+    style,
+    onKeyDown: consumerOnKeyDown,
+    "aria-label": ariaLabel,
+    "aria-labelledby": ariaLabelledby,
+    "aria-describedby": ariaDescribedby,
+    ...rest
+}) => {
 
     const contentRef = useRef<HTMLDivElement>(null);
     const previouslyFocused = useRef<HTMLElement | null>(null);
@@ -93,6 +105,11 @@ const ModalComponent: React.FC<React.PropsWithChildren<ModalProps>> = ({ show, o
     }, [show]);
 
     const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+        // Run the consumer's handler first; if it handles the event
+        // (preventDefault), don't also apply the a11y key handling.
+        consumerOnKeyDown?.(e);
+        if (e.defaultPrevented) return;
+
         if (!show) return;
 
         if (e.key === "Escape") {
@@ -139,7 +156,7 @@ const ModalComponent: React.FC<React.PropsWithChildren<ModalProps>> = ({ show, o
                     onKeyDown={onKeyDown}
                     {...rest}
                 >
-                    <div className="modal-dialog" role="dialog" aria-modal="true">
+                    <div className="modal-dialog" role="dialog" aria-modal="true" aria-label={ariaLabel} aria-labelledby={ariaLabelledby} aria-describedby={ariaDescribedby}>
                         <div className="modal-content" ref={contentRef} tabIndex={-1}>
                             {enhancedChildren}
                         </div>

--- a/moo-ds/src/components/__tests__/Modal.test.tsx
+++ b/moo-ds/src/components/__tests__/Modal.test.tsx
@@ -55,6 +55,106 @@ describe('Modal', () => {
 
       expect(screen.getByText('Inside')).toHaveFocus();
     });
+
+    it('traps Tab from the last focusable back to the first', () => {
+      render(
+        <Modal show onHide={vi.fn()}>
+          <Modal.Body>
+            <button type="button">First</button>
+            <button type="button">Last</button>
+          </Modal.Body>
+        </Modal>
+      );
+
+      const first = screen.getByText('First');
+      const last = screen.getByText('Last');
+      last.focus();
+
+      fireEvent.keyDown(last, { key: 'Tab' });
+
+      expect(first).toHaveFocus();
+    });
+
+    it('traps Shift+Tab from the first focusable back to the last', () => {
+      render(
+        <Modal show onHide={vi.fn()}>
+          <Modal.Body>
+            <button type="button">First</button>
+            <button type="button">Last</button>
+          </Modal.Body>
+        </Modal>
+      );
+
+      const first = screen.getByText('First');
+      const last = screen.getByText('Last');
+      first.focus();
+
+      fireEvent.keyDown(first, { key: 'Tab', shiftKey: true });
+
+      expect(last).toHaveFocus();
+    });
+
+    it('restores focus to the previously focused element on close', () => {
+      const { rerender } = render(
+        <>
+          <button type="button" data-testid="opener">Open</button>
+          <Modal show={false} onHide={vi.fn()}>
+            <Modal.Body><button type="button">Inside</button></Modal.Body>
+          </Modal>
+        </>
+      );
+
+      const opener = screen.getByTestId('opener');
+      opener.focus();
+      expect(opener).toHaveFocus();
+
+      rerender(
+        <>
+          <button type="button" data-testid="opener">Open</button>
+          <Modal show onHide={vi.fn()}>
+            <Modal.Body><button type="button">Inside</button></Modal.Body>
+          </Modal>
+        </>
+      );
+      expect(screen.getByText('Inside')).toHaveFocus();
+
+      rerender(
+        <>
+          <button type="button" data-testid="opener">Open</button>
+          <Modal show={false} onHide={vi.fn()}>
+            <Modal.Body><button type="button">Inside</button></Modal.Body>
+          </Modal>
+        </>
+      );
+
+      expect(opener).toHaveFocus();
+    });
+
+    it('forwards an accessible name to the dialog element', () => {
+      const { baseElement } = render(
+        <Modal show onHide={vi.fn()} aria-label="Settings">
+          <Modal.Body>Content</Modal.Body>
+        </Modal>
+      );
+
+      expect(baseElement.querySelector('.modal-dialog')).toHaveAttribute('aria-label', 'Settings');
+    });
+
+    it('runs a consumer onKeyDown and lets it suppress the a11y handling', () => {
+      const onHide = vi.fn();
+      const consumerKeyDown = vi.fn((e: { preventDefault: () => void }) => e.preventDefault());
+      const { baseElement } = render(
+        <Modal show onHide={onHide} onKeyDown={consumerKeyDown}>
+          <Modal.Body>Content</Modal.Body>
+        </Modal>
+      );
+
+      fireEvent.keyDown(baseElement.querySelector('.modal')!, { key: 'Escape' });
+
+      expect(consumerKeyDown).toHaveBeenCalledTimes(1);
+      // Consumer called preventDefault, so Escape-to-close is suppressed.
+      expect(onHide).not.toHaveBeenCalled();
+    });
   });
 
   describe('structure', () => {

--- a/moo-ds/src/components/__tests__/Modal.test.tsx
+++ b/moo-ds/src/components/__tests__/Modal.test.tsx
@@ -20,6 +20,43 @@ describe('Modal', () => {
     });
   });
 
+  describe('accessibility', () => {
+    it('exposes the dialog role and aria-modal', () => {
+      const { baseElement } = render(<Modal show onHide={vi.fn()}><Modal.Body>Content</Modal.Body></Modal>);
+      const dialog = baseElement.querySelector('.modal-dialog');
+      expect(dialog).toHaveAttribute('role', 'dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+    });
+
+    it('closes on Escape', () => {
+      const onHide = vi.fn();
+      const { baseElement } = render(<Modal show onHide={onHide}><Modal.Body>Content</Modal.Body></Modal>);
+
+      fireEvent.keyDown(baseElement.querySelector('.modal')!, { key: 'Escape' });
+
+      expect(onHide).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not close on Escape when hidden', () => {
+      const onHide = vi.fn();
+      const { baseElement } = render(<Modal show={false} onHide={onHide}><Modal.Body>Content</Modal.Body></Modal>);
+
+      fireEvent.keyDown(baseElement.querySelector('.modal')!, { key: 'Escape' });
+
+      expect(onHide).not.toHaveBeenCalled();
+    });
+
+    it('moves focus to the first focusable element on open', () => {
+      render(
+        <Modal show onHide={vi.fn()}>
+          <Modal.Body><button type="button">Inside</button></Modal.Body>
+        </Modal>
+      );
+
+      expect(screen.getByText('Inside')).toHaveFocus();
+    });
+  });
+
   describe('structure', () => {
     it('renders with modal class in portal', () => {
       const { baseElement } = render(<Modal show onHide={vi.fn()}><Modal.Body>Content</Modal.Body></Modal>);


### PR DESCRIPTION
Part 12 (final) of the review-remediation series (a11y, Milestone 4.2 / code-quality Phase 5). **Non-breaking.**

The custom portal `Modal` locked body scroll and closed on backdrop click but lacked the dialog accessibility baseline. Added:

- **`role="dialog"` + `aria-modal="true"`** on the modal dialog.
- **Escape-to-close** (only when shown).
- **Focus trap** — focus moves into the dialog on open (first focusable element, or the content container), Tab / Shift+Tab cycle within the dialog, and focus is restored to the previously-focused element on close.

## Verification
- `moo-ds` type-check clean
- Full `moo-ds` suite passes: **1203 tests**. Regression tests added for the dialog role/`aria-modal`, Escape handling, and focus-on-open.

## Note
`aria-labelledby` wiring to `Modal.Title` was left out (it needs id plumbing through the compound children) — a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)