### PR TITLE
Adopt stated-version release strategy (drop GitVersion)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
     # Publish only from main (the stable trunk) or a prerelease line (a branch whose stated
     # version carries a suffix). Suffix-less non-main branches (incl. PRs) publish nothing.
     - name: Publish
-      if: github.ref == 'refs/heads/main' || steps.version.outputs.is-prerelease == 'true'
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || steps.version.outputs.is-prerelease == 'true')
       env:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: npm publish --workspace=moo-ds --workspace=moo-app --workspace=moo-icons

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,9 @@ jobs:
         fetch-depth: 0          # required: full history for the commit count
     # Version is stated in package.json (Major.Minor + optional -suffix); the patch is the
     # number of commits since the version line last changed. See docs/release-branching-strategy.md.
-    # Pinned to the get-node-version PR commit for pre-merge testing; switch to
-    # AndrewMcLachlan/Actions/get-node-version@v4 once that PR is merged and released.
     - name: Get version
       id: version
-      uses: AndrewMcLachlan/Actions/get-node-version@9371a2640b3d6667e23199c38f82cd812dc4a0cc
+      uses: AndrewMcLachlan/Actions/get-node-version@v4
     - run: echo "::notice::Version ${{ steps.version.outputs.version }}"
     - uses: actions/setup-node@v6
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,20 +17,14 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        fetch-depth: 0
-    - uses: gittools/actions/gitversion/setup@v4.7.0
-      with:
-        versionSpec: '6.x'
-    - id: gitversion
-      uses: gittools/actions/gitversion/execute@v4.7.0
-    - name: Set version
+        fetch-depth: 0          # required: full history for the commit count
+    # Version is stated in package.json (Major.Minor + optional -suffix); the patch is the
+    # number of commits since the version line last changed. See docs/release-branching-strategy.md.
+    # Pinned to the get-node-version PR commit for pre-merge testing; switch to
+    # AndrewMcLachlan/Actions/get-node-version@v4 once that PR is merged and released.
+    - name: Get version
       id: version
-      run: |
-        if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-          echo "version=${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.commitsSinceVersionSource }}" >> "$GITHUB_OUTPUT"
-        else
-          echo "version=${{ steps.gitversion.outputs.semVer }}" >> "$GITHUB_OUTPUT"
-        fi
+      uses: AndrewMcLachlan/Actions/get-node-version@9371a2640b3d6667e23199c38f82cd812dc4a0cc
     - run: echo "::notice::Version ${{ steps.version.outputs.version }}"
     - uses: actions/setup-node@v6
       with:
@@ -42,7 +36,10 @@ jobs:
     - run: npm pkg set version=${{ steps.version.outputs.version }} --workspace=moo-ds --workspace=moo-app --workspace=moo-icons
     - run: npm run test:run
     - run: npm run build --workspace=moo-ds --workspace=moo-app --workspace=moo-icons
-    - if: github.ref == 'refs/heads/main'
+    # Publish only from main (the stable trunk) or a prerelease line (a branch whose stated
+    # version carries a suffix). Suffix-less non-main branches (incl. PRs) publish nothing.
+    - name: Publish
+      if: github.ref == 'refs/heads/main' || steps.version.outputs.is-prerelease == 'true'
       env:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: npm publish --workspace=moo-ds --workspace=moo-app --workspace=moo-icons

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,0 @@
-workflow: GitHubFlow/v1
-branches:
-  main:
-    is-main-branch: true
-    mode: ContinuousDeployment
-  feature:
-    label: beta

--- a/docs/release-branching-strategy.md
+++ b/docs/release-branching-strategy.md
@@ -51,7 +51,8 @@ isolated — no shared tags, no cross-talk.
 - **`main` is the trunk.** PRs and Dependabot land here; every merge publishes `X.Y.<count>` (stable).
 - **`feature/*` / PRs** build and test but never publish.
 - **A preview line is a `release/**` branch whose stated version carries a suffix** — e.g. branch
-  `release/6.0-beta`, set `"version": "6.0.0-beta"` → publishes `6.0.0-beta.N` while `main` stays on
+  `release/6.0-beta`, set `"version": "6.0.0-beta"` → publishes `6.0.0-beta.N` when the build workflow
+  is run (via `workflow_dispatch`, or by expanding the workflow `on.push.branches` to include `release/**`), while `main` stays on
   `5.x`.
 
 **Publishing is gated in CI to `main` (the stable trunk) and prerelease builds** — i.e. `main`, or

--- a/docs/release-branching-strategy.md
+++ b/docs/release-branching-strategy.md
@@ -1,0 +1,76 @@
+# Release Branching & Versioning
+
+How the MooApp packages (`moo-ds`, `moo-app`, `moo-icons`) are versioned and published.
+**The version is *stated*, never inferred** — no GitVersion, no tags, no version-bump ceremony.
+
+## The version
+
+The current `Major.Minor` is declared in the **root `package.json`** `version` field:
+
+```jsonc
+{
+  "version": "5.2.0"
+  // for a prerelease line, state a suffix instead:
+  // "version": "6.0.0-beta"
+}
+```
+
+The stated patch is ignored — CI (`.github/workflows/build.yml`, via
+[`AndrewMcLachlan/Actions/get-node-version`](https://github.com/AndrewMcLachlan/Actions)) turns the
+stated version into the published version:
+
+- **Patch = commits since the version line last changed.** Specifically
+  `git rev-list --count "$(git log -1 --format=%H -G'"version":' -- package.json)"..HEAD`.
+  The `-G'"version":'` scopes the counter to commits that actually changed the `"version"` line, so
+  **editing `package.json` for any other reason (adding a dependency, a script) does not reset the
+  patch**.
+- Stable → `Major.Minor.<count>` (e.g. `5.2.17`). Prerelease → `Major.Minor.0-<suffix>.<count>`
+  (e.g. `6.0.0-beta.4`).
+
+**Monorepo:** the root `package.json` is the single source of truth. CI applies the computed version
+to every published workspace before building and publishing:
+
+```
+npm pkg set version=<computed> --workspace=moo-ds --workspace=moo-app --workspace=moo-icons
+```
+
+The committed workspace `version` fields are just placeholders (kept in sync with the root for
+tidiness); the published value is always the computed one.
+
+**To bump the minor or major:** edit the root `version` (`5.2` → `5.3` / `6.0`) and commit. That
+commit resets the patch, so the next publish is `X.Y.0`. That single, reviewable edit *is* the
+deliberate version decision — nothing else to do. (Remember to keep the workspace `version` fields
+and `package-lock.json` in sync, e.g. `npm pkg set version=X.Y.0` for the root + workspaces, then
+`npm install --package-lock-only`.)
+
+## Branching
+
+Because the version lives in `package.json` *on the branch*, every branch is self-describing and
+isolated — no shared tags, no cross-talk.
+
+- **`main` is the trunk.** PRs and Dependabot land here; every merge publishes `X.Y.<count>` (stable).
+- **`feature/*` / PRs** build and test but never publish.
+- **A preview line is a `release/**` branch whose stated version carries a suffix** — e.g. branch
+  `release/6.0-beta`, set `"version": "6.0.0-beta"` → publishes `6.0.0-beta.N` while `main` stays on
+  `5.x`.
+
+**Publishing is gated in CI to `main` (the stable trunk) and prerelease builds** — i.e. `main`, or
+any branch whose stated version carries a suffix (`is-prerelease`). A `release/**` branch with no
+suffix publishes nothing (that's what lets you graduate a beta in place — see below).
+
+## Graduating a preview to GA
+
+Because a suffix-less `release/**` branch publishes nothing, you graduate **in place** — no
+promotion or integration branch:
+
+1. On `release/6.0-beta`, remove the `-beta` suffix (`"version": "6.0.0"`) and commit. The build runs
+   but **publishes nothing** (stable, but not `main`).
+2. Merge `release/6.0-beta` → `main`. `main` publishes **`6.0.0`** (removing the suffix reset the patch).
+3. Delete `release/6.0-beta`.
+
+## Cutting a new major/minor
+
+- **Minor / non-breaking:** edit the root `version` on `main` (`5.2` → `5.3`) in a normal PR; the next
+  merge publishes `5.3.0`.
+- **Breaking major (previewed):** branch `release/6.0-beta`, set `"version": "6.0.0-beta"`, then
+  graduate as above.

--- a/moo-app/package.json
+++ b/moo-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andrewmclachlan/moo-app",
-  "version": "4.0.0",
+  "version": "5.2.0",
   "type": "module",
   "main": "dist/index.es.js",
   "types": "dist/index.d.ts",

--- a/moo-ds/package.json
+++ b/moo-ds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andrewmclachlan/moo-ds",
-  "version": "4.0.0",
+  "version": "5.2.0",
   "type": "module",
   "main": "dist/index.es.js",
   "types": "dist/index.d.ts",

--- a/moo-icons/package.json
+++ b/moo-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andrewmclachlan/moo-icons",
-  "version": "4.0.0",
+  "version": "5.2.0",
   "type": "module",
   "files": [
     "dist"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mooapp-packages",
-  "version": "4.0.0",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mooapp-packages",
-      "version": "4.0.0",
+      "version": "5.2.0",
       "workspaces": [
         "moo-ds",
         "moo-app",
@@ -101,7 +101,7 @@
     },
     "moo-app": {
       "name": "@andrewmclachlan/moo-app",
-      "version": "4.0.0",
+      "version": "5.2.0",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "^5.17.0",
@@ -351,7 +351,7 @@
     },
     "moo-ds": {
       "name": "@andrewmclachlan/moo-ds",
-      "version": "4.0.0",
+      "version": "5.2.0",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-table": "^8.21.0",
@@ -595,7 +595,7 @@
     },
     "moo-icons": {
       "name": "@andrewmclachlan/moo-icons",
-      "version": "4.0.0",
+      "version": "5.2.0",
       "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mooapp-packages",
-  "version": "4.0.0",
+  "version": "5.2.0",
   "description": "A collection of packages for the MooApp framework",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Migrates CI versioning from **GitVersion** to the [stated-version release strategy](./docs/release-branching-strategy.md): the version lives in `package.json` (Major.Minor + optional `-suffix`) and CI computes the patch as commits since the version line last changed. No GitVersion, no tags, no version-bump ceremony.

Uses the new **`get-node-version`** action from AndrewMcLachlan/Actions#30, **pinned to that PR's commit** (`9371a26`) so we can test the whole thing end-to-end **before merging or releasing anything**.

## Changes
- `build.yml`: replaced the `gittools/actions` GitVersion steps with `AndrewMcLachlan/Actions/get-node-version@9371a26`; publish gate widened to `main` **or** a prerelease line (`is-prerelease`).
- Stated version set to **`5.2.0`** — the next minor above the published `5.1.x` line, so the first `main` publish can't collide with an existing version. Root `package.json` is the source of truth; the three published workspaces + `package-lock.json` are set to match (so `npm ci` stays in sync).
- Removed `GitVersion.yml`.
- Added `docs/release-branching-strategy.md` (adapted for this Node monorepo).

## What CI will compute
Verified locally with the pinned action against this branch tip:
```
version=5.2.0  major=5  minor=2  patch=0  version-suffix=  is-prerelease=false
```
(The version-bump commit is the anchor, so patch counts from it; the first `main` publish after merge will be `5.2.<small N>`.)

## How to test (nothing publishes from this PR)
This PR's own CI run should:
1. Resolve `get-node-version@9371a26` and emit a `5.2.x` version notice.
2. `npm ci` cleanly (lockfile is synced to 5.2.0), run `test:run`, and build all three packages.
3. **Skip the publish step** (not `main`, not a prerelease) — check the `Publish` step shows as skipped.

## After it's verified
1. Merge AndrewMcLachlan/Actions#30 and cut an Actions release so `get-node-version` is included under the moving `@v4` tag.
2. Change the `uses:` here from the pinned commit to `AndrewMcLachlan/Actions/get-node-version@v4`.
3. Merge this PR → `main` publishes `5.2.x`.

> Depends on AndrewMcLachlan/Actions#30 (the pinned commit must stay pushed). Do not merge before switching to `@v4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)