### PR TITLE
demoo: resolve moo-ds/moo-app to workspace source for type-checking

### DIFF
--- a/demoo/src/index.tsx
+++ b/demoo/src/index.tsx
@@ -173,6 +173,7 @@ const routeTree = rootRoute.addChildren([
   iconsRoute,
 ]);
 
+// @ts-expect-error strictNullChecks is false (to match the moo-ds/moo-app source) — TanStack Router requires it for full type safety
 const router = createRouter({ routeTree });
 
 root.render(

--- a/demoo/src/react-app-env.d.ts
+++ b/demoo/src/react-app-env.d.ts
@@ -1,4 +1,8 @@
-/// <reference types="react-scripts" />
+/// <reference types="vite/client" />
+
+// Side-effect CSS imports (demoo's own and the design-system source pulled in
+// via the workspace path mappings).
+declare module "*.css" {}
 
 declare module "*.svg" {
   import * as React from "react";

--- a/demoo/tsconfig.json
+++ b/demoo/tsconfig.json
@@ -28,7 +28,9 @@
 
     /* Resolve the workspace packages to their source, mirroring the vite
        aliases in vite.config.ts, so type-checking matches what actually runs
-       (instead of the stale published packages in node_modules). */
+       (instead of the stale published packages in node_modules). No baseUrl:
+       it was removed in TypeScript 7 (error TS5102) — paths resolve relative to
+       this tsconfig. */
     "paths": {
       "@andrewmclachlan/moo-ds": ["../moo-ds/src"],
       "@andrewmclachlan/moo-app": ["../moo-app/src"],

--- a/demoo/tsconfig.json
+++ b/demoo/tsconfig.json
@@ -16,10 +16,24 @@
 
     /* Linting */
     "strict": true,
+    // Match the workspace libraries (moo-ds/moo-app) so their source — now
+    // resolved via the paths below — type-checks under the same rules it was
+    // written for, rather than demoo's default strict-null behaviour.
+    "strictNullChecks": false,
+    "moduleDetection": "force",
     //"noUnusedLocals": true,
     //"noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
+
+    /* Resolve the workspace packages to their source, mirroring the vite
+       aliases in vite.config.ts, so type-checking matches what actually runs
+       (instead of the stale published packages in node_modules). */
+    "paths": {
+      "@andrewmclachlan/moo-ds": ["../moo-ds/src"],
+      "@andrewmclachlan/moo-app": ["../moo-app/src"],
+      "@andrewmclachlan/moo-icons": ["../moo-icons/src"],
+    },
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
demoo's **vite build** already aliases `@andrewmclachlan/moo-ds` / `moo-app` / `moo-icons` to their `src`, but its **tsconfig had no matching `paths`** — so `tsc` and the IDE resolved to the stale *published* packages in `node_modules`, producing false errors against an old API (e.g. `client` required, `useHttpClient` missing).

## Changes (demoo only)
- **tsconfig `paths`** mirroring the vite aliases → type-checking now matches what actually runs.
- **`strictNullChecks: false` + `moduleDetection: "force"`** to match moo-ds/moo-app (whose source is now checked via the paths and is written for those settings — the whole monorepo runs `strictNullChecks: false`).
- **`@ts-expect-error` on `createRouter`** — TanStack Router's types demand `strictNullChecks: true`; this is the same pattern MooBank uses as a consumer.
- **`*.css` module declaration** + switch the ambient reference from the legacy `react-scripts` to `vite/client`.

## Verification
- `tsc --noEmit -p demoo/tsconfig.json` → **0 errors** (was 40+ against source / false errors against the stale package).
- `npm run build -w demoo` (vite) unaffected — builds clean.

No library or app code changed; this is purely demoo's dev/type-check configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)