### PR TITLE
fix(moo-ds): keep dashboard widget titles pinned to the top while loading

### DIFF
--- a/moo-ds/src/css/pages/_dashboard.css
+++ b/moo-ds/src/css/pages/_dashboard.css
@@ -32,10 +32,12 @@ main.dashboard {
         flex-direction: column;
         overflow: hidden;
 
-        /* Pin the widget title to the top. While a widget loads, its chart's spinner is absolutely
+        /* Pin the widget header to the top. While a widget loads, its chart's spinner is absolutely
            positioned, so the header can be the only in-flow item — and the section's alignment would
-           otherwise drift it downward. align-self keeps it top-anchored in both states. */
-        > .section-header {
+           otherwise drift it downward. Target the first child rather than .section-header: Section
+           renders a string header as <h*.section-header> but a ReactNode header directly (no class),
+           so this keeps both kinds top-anchored. */
+        > :first-child {
             align-self: start;
         }
 

--- a/moo-ds/src/css/pages/_dashboard.css
+++ b/moo-ds/src/css/pages/_dashboard.css
@@ -32,6 +32,13 @@ main.dashboard {
         flex-direction: column;
         overflow: hidden;
 
+        /* Pin the widget title to the top. While a widget loads, its chart's spinner is absolutely
+           positioned, so the header can be the only in-flow item — and the section's alignment would
+           otherwise drift it downward. align-self keeps it top-anchored in both states. */
+        > .section-header {
+            align-self: start;
+        }
+
         > *:not(.section-header) {
             flex: none;
             min-height: 0;


### PR DESCRIPTION
## What
Dashboard widget titles drift downward while the widget is loading, instead of staying pinned to the top.

## Cause
The dashboard `.section` renders as a grid with centred alignment. When loaded, its rows are filled (header, value, chart) so the header sits in the top row. During load the chart's spinner is `position: absolute` (out of flow), leaving the header as the only in-flow item — so the centred alignment drifts it down. Measured in a consuming app: header offset 16px loaded → 55px loading.

## Fix
```css
main.dashboard .section > .section-header { align-self: start; }
```
Top-anchors just the header, leaving the rest of the section's alignment intact. Verified in a running app by simulating the loading state — the header returns to 16px in both states. Fixes every dashboard widget, not only chart ones.

Currently shipped as a local override in the MooBank app; this lifts it into moo-ds so all consumers get it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)