### PR TITLE
ComboBox: single-line collapse + focus-on-click

### DIFF
--- a/demoo/src/App.tsx
+++ b/demoo/src/App.tsx
@@ -60,6 +60,11 @@ const App = () => {
       image: <Icon icon={Stack} />
     },
     {
+      text: "ComboBox",
+      route: "/combo-box",
+      image: <Icon icon={Sliders} />
+    },
+    {
       text: "Data Grid",
       route: "/data-grid",
       image: <Icon icon={Tags} />

--- a/demoo/src/index.tsx
+++ b/demoo/src/index.tsx
@@ -23,6 +23,7 @@ import { Overlays } from "./routes/Overlays";
 import { DataGridPage } from "./routes/DataGrid";
 import { Icons } from "./routes/Icons";
 import { SkeletonPage } from "./routes/Skeleton";
+import { ComboBoxPage } from "./routes/ComboBox";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
@@ -157,6 +158,12 @@ const skeletonRoute = createRoute({
   component: SkeletonPage,
 });
 
+const comboBoxRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "combo-box",
+  component: ComboBoxPage,
+});
+
 const routeTree = rootRoute.addChildren([
   indexRoute,
   componentsRoute.addChildren([
@@ -180,6 +187,7 @@ const routeTree = rootRoute.addChildren([
   dataGridRoute,
   iconsRoute,
   skeletonRoute,
+  comboBoxRoute,
 ]);
 
 // @ts-expect-error strictNullChecks is false (to match the moo-ds/moo-app source) — TanStack Router requires it for full type safety

--- a/demoo/src/routes/ComboBox.tsx
+++ b/demoo/src/routes/ComboBox.tsx
@@ -14,7 +14,6 @@ export const ComboBoxPage = () => {
 
     const items = useMemo<Tag[]>(() => NAMES.map((text, id) => ({ id, text, colour: "#8b0000" })), []);
 
-    // Pre-select many so the collapsed "+N more" and expand-on-focus are visible.
     const [many, setMany] = useState<Tag[]>(() => items.slice(0, 8));
     const [few, setFew] = useState<Tag[]>(() => items.slice(4, 6));
     const [inCell, setInCell] = useState<Tag[]>(() => items.slice(0, 7));
@@ -32,21 +31,18 @@ export const ComboBoxPage = () => {
     return (
         <Page title="ComboBox" breadcrumbs={[{ route: "/combo-box", text: "ComboBox" }]}>
 
-            <Section title="Many selections" header="Many selections (collapses to +N more)" headerSize={4}>
+            <Section title="Many selections" header="Many selections (collapse to one row)" headerSize={4}>
                 <p>
-                    Inactive, the pills collapse to the first few plus a &ldquo;+N more&rdquo; chip.
-                    Click anywhere (except a remove &times;) to expand and focus the input.
-                    <code>collapseAfter</code> defaults to 5.
+                    While the dropdown is closed, the pills collapse to however many fit on a single
+                    row plus a &ldquo;+N more&rdquo; chip. Click anywhere (except a remove &times;) to
+                    open it &mdash; that expands to every pill and focuses the input. Resize the window
+                    to see the fit re-measure.
                 </p>
                 <ComboBox {...common} selectedItems={many} onChange={setMany} />
             </Section>
 
-            <Section title="Few selections" header="Few selections (no collapse)" headerSize={4}>
+            <Section title="Few selections" header="Few selections (all fit, no chip)" headerSize={4}>
                 <ComboBox {...common} selectedItems={few} onChange={setFew} />
-            </Section>
-
-            <Section title="Lower threshold" header="collapseAfter = 3" headerSize={4}>
-                <ComboBox {...common} collapseAfter={3} selectedItems={many} onChange={setMany} />
             </Section>
 
             <SectionTable header="In a table" headerSize={4} striped hover>
@@ -59,11 +55,11 @@ export const ComboBoxPage = () => {
                 <tbody>
                     <tr>
                         <td>Everyday</td>
-                        <td><ComboBox {...common} collapseAfter={3} selectedItems={inCell} onChange={setInCell} /></td>
+                        <td><ComboBox {...common} selectedItems={inCell} onChange={setInCell} /></td>
                     </tr>
                     <tr>
                         <td>Savings</td>
-                        <td><ComboBox {...common} collapseAfter={3} selectedItems={few} onChange={setFew} /></td>
+                        <td><ComboBox {...common} selectedItems={few} onChange={setFew} /></td>
                     </tr>
                 </tbody>
             </SectionTable>

--- a/demoo/src/routes/ComboBox.tsx
+++ b/demoo/src/routes/ComboBox.tsx
@@ -1,0 +1,73 @@
+import { Page } from "@andrewmclachlan/moo-app";
+import { ComboBox, Section, SectionTable } from "@andrewmclachlan/moo-ds";
+import { useMemo, useState } from "react";
+
+type Tag = { id: number; text: string; colour: string };
+
+const NAMES = [
+    "Alcohol", "Aldi", "Amazon Prime", "Andy", "General Shopping", "Pharmacy",
+    "Fuel", "Groceries", "Utilities", "Dining Out", "Subscriptions", "Transport",
+    "Insurance", "Healthcare", "Entertainment", "Clothing", "Gifts", "Hardware",
+];
+
+export const ComboBoxPage = () => {
+
+    const items = useMemo<Tag[]>(() => NAMES.map((text, id) => ({ id, text, colour: "#8b0000" })), []);
+
+    // Pre-select many so the collapsed "+N more" and expand-on-focus are visible.
+    const [many, setMany] = useState<Tag[]>(() => items.slice(0, 8));
+    const [few, setFew] = useState<Tag[]>(() => items.slice(4, 6));
+    const [inCell, setInCell] = useState<Tag[]>(() => items.slice(0, 7));
+
+    const common = {
+        items,
+        labelField: (i: Tag) => i.text,
+        valueField: (i: Tag) => i.id,
+        colourField: (i: Tag) => i.colour,
+        multiSelect: true,
+        clearable: true,
+        placeholder: "Select...",
+    } as const;
+
+    return (
+        <Page title="ComboBox" breadcrumbs={[{ route: "/combo-box", text: "ComboBox" }]}>
+
+            <Section title="Many selections" header="Many selections (collapses to +N more)" headerSize={4}>
+                <p>
+                    Inactive, the pills collapse to the first few plus a &ldquo;+N more&rdquo; chip.
+                    Click anywhere (except a remove &times;) to expand and focus the input.
+                    <code>collapseAfter</code> defaults to 5.
+                </p>
+                <ComboBox {...common} selectedItems={many} onChange={setMany} />
+            </Section>
+
+            <Section title="Few selections" header="Few selections (no collapse)" headerSize={4}>
+                <ComboBox {...common} selectedItems={few} onChange={setFew} />
+            </Section>
+
+            <Section title="Lower threshold" header="collapseAfter = 3" headerSize={4}>
+                <ComboBox {...common} collapseAfter={3} selectedItems={many} onChange={setMany} />
+            </Section>
+
+            <SectionTable header="In a table" headerSize={4} striped hover>
+                <thead>
+                    <tr>
+                        <th className="column-25">Account</th>
+                        <th>Tags</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Everyday</td>
+                        <td><ComboBox {...common} collapseAfter={3} selectedItems={inCell} onChange={setInCell} /></td>
+                    </tr>
+                    <tr>
+                        <td>Savings</td>
+                        <td><ComboBox {...common} collapseAfter={3} selectedItems={few} onChange={setFew} /></td>
+                    </tr>
+                </tbody>
+            </SectionTable>
+
+        </Page>
+    );
+}

--- a/moo-ds/src/components/comboBox/ComboBoxContainer.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import classNames from "classnames";
 
 import { useClickAway } from "../../hooks";
@@ -12,7 +12,7 @@ import { ComboBoxSingleSelectedItem as SingleSelectedItem } from "./ComboBoxSing
 
 export const ComboBoxContainer: React.FC<ComboBoxContainerProps> = ({ placeholder, readonly = false, hidden = false, id, className, tabIndex }) => {
 
-    const { multiSelect, selectedItems, show, setShow, setShowInput, valueField } = useComboBox();
+    const { multiSelect, selectedItems, setShow, showInput, setShowInput, valueField, collapseAfter } = useComboBox();
 
     const divRef = useRef<HTMLDivElement>(null);
 
@@ -23,11 +23,33 @@ export const ComboBoxContainer: React.FC<ComboBoxContainerProps> = ({ placeholde
 
     useClickAway(setAllShow, divRef as React.RefObject<any>);
 
+    const focusInput = () => divRef.current?.querySelector<HTMLInputElement>("input")?.focus();
+
+    // Focus the input once it un-hides on activation (it can't be focused while
+    // hidden, so this runs after the show-driven re-render).
+    useEffect(() => {
+        if (showInput && !readonly) focusInput();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [showInput]);
+
+    const activate = () => {
+        setShow(true);
+        setShowInput(true);
+        focusInput();
+    };
+
+    // Collapse the pills to the first N + a "+X more" chip while inactive, so a
+    // large selection doesn't grow the control. Activating expands to all pills.
+    const collapsed = !!multiSelect && !showInput && selectedItems.length > collapseAfter;
+    const visibleItems = collapsed ? selectedItems.slice(0, collapseAfter) : selectedItems;
+    const hiddenCount = selectedItems.length - visibleItems.length;
+
     return (
-        <div id={id} ref={divRef} className={classNames("combo-box", readonly ? "readonly" : "", className)} hidden={hidden} onClick={() => { setShow(!show); setShowInput(true); }} onKeyUp={key => key.key === "Escape" && setShow(false)}>
+        <div id={id} ref={divRef} className={classNames("combo-box", readonly ? "readonly" : "", className)} hidden={hidden} onClick={activate} onKeyUp={key => key.key === "Escape" && setShow(false)}>
             <div>
                 <div className="body">
-                    {!!multiSelect && selectedItems.map(item => <SelectedItem key={valueField(item)?.toString()} item={item} />)}
+                    {!!multiSelect && visibleItems.map(item => <SelectedItem key={valueField(item)?.toString()} item={item} />)}
+                    {hiddenCount > 0 && <span className="cb-more" aria-hidden="true">+{hiddenCount} more</span>}
                     {!multiSelect && selectedItems.length > 0 && <SingleSelectedItem />}
                     <Input placeholder={placeholder} readonly={readonly} tabIndex={tabIndex} />
                 </div>

--- a/moo-ds/src/components/comboBox/ComboBoxContainer.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxContainer.tsx
@@ -7,49 +7,43 @@ import { ComboBoxInput as Input } from "./ComboBoxInput";
 import { ComboBoxControls as Controls } from "./ComboBoxControls";
 import { type ComboBoxProps, useComboBox } from "./ComboBoxProvider";
 import { ComboBoxList as List } from "./ComboBoxList";
-import { ComboBoxSelectedItem as SelectedItem } from "./ComboBoxSelectedItem";
+import { ComboBoxPills as Pills } from "./ComboBoxPills";
 import { ComboBoxSingleSelectedItem as SingleSelectedItem } from "./ComboBoxSingleSelectedItem";
 
 export const ComboBoxContainer: React.FC<ComboBoxContainerProps> = ({ placeholder, readonly = false, hidden = false, id, className, tabIndex }) => {
 
-    const { multiSelect, selectedItems, setShow, showInput, setShowInput, valueField, collapseAfter } = useComboBox();
+    const { multiSelect, selectedItems, show, setShow, setShowInput } = useComboBox();
 
     const divRef = useRef<HTMLDivElement>(null);
 
-    const setAllShow = (show: boolean) => {
-        setShow(show);
-        setShowInput(show);
+    const setAllShow = (value: boolean) => {
+        setShow(value);
+        setShowInput(value);
     };
 
     useClickAway(setAllShow, divRef as React.RefObject<any>);
 
     const focusInput = () => divRef.current?.querySelector<HTMLInputElement>("input")?.focus();
 
-    // Focus the input once it un-hides on activation (it can't be focused while
-    // hidden, so this runs after the show-driven re-render).
+    // Opening the control (dropdown) also un-hides the input, so focus it once
+    // that has happened.
     useEffect(() => {
-        if (showInput && !readonly) focusInput();
+        if (show && !readonly) focusInput();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [showInput]);
+    }, [show]);
 
+    // Any click in the control opens it and focuses the input. Remove-x / clear-x
+    // stop propagation, so they don't trigger this.
     const activate = () => {
-        setShow(true);
-        setShowInput(true);
+        setAllShow(true);
         focusInput();
     };
-
-    // Collapse the pills to the first N + a "+X more" chip while inactive, so a
-    // large selection doesn't grow the control. Activating expands to all pills.
-    const collapsed = !!multiSelect && !showInput && selectedItems.length > collapseAfter;
-    const visibleItems = collapsed ? selectedItems.slice(0, collapseAfter) : selectedItems;
-    const hiddenCount = selectedItems.length - visibleItems.length;
 
     return (
         <div id={id} ref={divRef} className={classNames("combo-box", readonly ? "readonly" : "", className)} hidden={hidden} onClick={activate} onKeyUp={key => key.key === "Escape" && setShow(false)}>
             <div>
                 <div className="body">
-                    {!!multiSelect && visibleItems.map(item => <SelectedItem key={valueField(item)?.toString()} item={item} />)}
-                    {hiddenCount > 0 && <span className="cb-more" aria-hidden="true">+{hiddenCount} more</span>}
+                    {!!multiSelect && <Pills />}
                     {!multiSelect && selectedItems.length > 0 && <SingleSelectedItem />}
                     <Input placeholder={placeholder} readonly={readonly} tabIndex={tabIndex} />
                 </div>

--- a/moo-ds/src/components/comboBox/ComboBoxControls.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxControls.tsx
@@ -1,16 +1,24 @@
+import { type MouseEvent } from "react";
 import classNames from "classnames";
 import { useComboBox } from "./ComboBoxProvider";
 
 export const ComboBoxControls = () => {
 
-    const { selectedItems, clear, clearable } = useComboBox();
+    const { selectedItems, clear, clearable, show, setShow } = useComboBox();
 
     const showClear = !!clearable && selectedItems?.length > 0;
+
+    // The chevron is a control: it toggles the dropdown and stops the click from
+    // reaching the container (which always opens + focuses the input).
+    const toggle = (e: MouseEvent) => {
+        e.stopPropagation();
+        setShow(!show);
+    };
 
     return (
         <div className={classNames("controls", showClear ? "clearable" : "")}>
             {showClear && <div><svg onClick={clear} height="20" width="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" className="clear-input"><path d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"></path></svg></div>}
-            <div><svg xmlns='http://www.w3.org/2000/svg' height={16} width={16} viewBox='0 0 16 16'><path fill='none' strokeLinecap='round' strokeLinejoin='round' strokeWidth='2' d='m2 5 6 6 6-6' className="drop-down-chevron" /></svg></div>
+            <div onClick={toggle}><svg xmlns='http://www.w3.org/2000/svg' height={16} width={16} viewBox='0 0 16 16'><path fill='none' strokeLinecap='round' strokeLinejoin='round' strokeWidth='2' d='m2 5 6 6 6-6' className="drop-down-chevron" /></svg></div>
         </div>
     );
 };

--- a/moo-ds/src/components/comboBox/ComboBoxInput.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxInput.tsx
@@ -4,7 +4,7 @@ import { useInnerRef } from "../../hooks";
 
 export const ComboBoxInput = ({ placeholder, ...props }: ComboBoxInputProps) => {
 
-    const { createLabel, creatable, allItems, labelField, search, setItems, selectedItems, newItem, setNewItem, show, showInput, text, setText, setShow, ref, listId } = useComboBox();
+    const { createLabel, creatable, allItems, labelField, search, setItems, selectedItems, newItem, setNewItem, show, text, setText, setShow, ref, listId } = useComboBox();
 
     // Debounce the actual search execution. Previously `useDebounce(search, 300)`
     // debounced the function *value* (a stable reference), so the search ran
@@ -51,7 +51,9 @@ export const ComboBoxInput = ({ placeholder, ...props }: ComboBoxInputProps) => 
         }
     }
 
-    const inputVisible = selectedItems?.length === 0 || !!showInput;
+    // While the dropdown is closed the selected pills stand in for the input;
+    // opening it reveals the input for typing/searching.
+    const inputVisible = selectedItems?.length === 0 || !!show;
 
     const innerRef = useInnerRef<HTMLInputElement>(ref);
 

--- a/moo-ds/src/components/comboBox/ComboBoxPills.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxPills.tsx
@@ -2,15 +2,19 @@ import { useLayoutEffect, useRef, useState } from "react";
 import { useComboBox } from "./ComboBoxProvider";
 import { ComboBoxSelectedItem as SelectedItem } from "./ComboBoxSelectedItem";
 
-// Renders the multi-select pills. While the dropdown is closed the pills
-// collapse to however many fit on a single row plus a "+N more" chip; when it's
-// open (actively choosing) every pill is shown.
+// Rough px reserved on the row for the trailing "+N more" chip and (when the
+// dropdown is open) the text input. Slightly generous so content never wraps.
+const CHIP_RESERVE = 56;
+const INPUT_RESERVE = 100;
+
+// Renders the multi-select pills on a single row: as many as fit, then a
+// "+N more" chip for the rest. When the dropdown is open, room is also kept for
+// the input so the control never grows past one line — managing the full set
+// happens through the dropdown.
 //
-// To know how many fit, every pill is rendered during a short "measure" pass and
-// their row (offsetTop) is read; the overflow is then dropped and replaced by the
-// chip. A single set of pills is used (no off-screen clone), so the DOM isn't
-// duplicated. Measuring needs real layout, so where it's unavailable (jsdom/SSR)
-// it falls back to showing every pill.
+// The fit is measured from real layout (every pill is rendered for one pass,
+// their widths read, then the overflow dropped). A single set of pills is used
+// (no clone). Where layout is unavailable (jsdom/SSR) it shows every pill.
 export const ComboBoxPills = () => {
 
     const { selectedItems, show, valueField } = useComboBox();
@@ -19,47 +23,69 @@ export const ComboBoxPills = () => {
     const [fit, setFit] = useState(selectedItems.length);
     const [measuring, setMeasuring] = useState(true);
 
-    const collapsed = !show && selectedItems.length > 0;
     const count = selectedItems.length;
 
-    // Re-measure whenever the collapse state or the number of pills changes.
+    // Re-measure when the pills or the open state (which reserves input room) change.
     useLayoutEffect(() => {
-        if (collapsed) setMeasuring(true);
-    }, [collapsed, count]);
+        setMeasuring(true);
+    }, [count, show]);
 
-    // Measure pass: with every pill rendered, count the ones on the first row.
+    // Measure pass: with every pill rendered, greedily keep the ones that fit.
     useLayoutEffect(() => {
-        if (!collapsed || !measuring) return;
+        if (!measuring) return;
         const wrap = wrapRef.current;
-        if (!wrap) return;
+        const body = wrap?.parentElement;
+        if (!wrap || !body) return;
 
         const pills = Array.from(wrap.querySelectorAll<HTMLElement>(".item"));
-        if (pills.length > 0) {
-            const firstTop = pills[0].offsetTop;
-            const firstRow = pills.filter(p => p.offsetTop <= firstTop + 1).length;
-            // Reserve a slot for the "+N more" chip when there's overflow.
-            setFit(firstRow >= pills.length ? pills.length : Math.max(1, firstRow - 1));
+        const style = getComputedStyle(body);
+        const avail = body.clientWidth - parseFloat(style.paddingLeft || "0") - parseFloat(style.paddingRight || "0");
+
+        // No layout available (e.g. jsdom): show every pill.
+        if (pills.length === 0 || !avail) {
+            setFit(pills.length);
+            setMeasuring(false);
+            return;
         }
+
+        const gap = parseFloat(style.columnGap || style.gap) || 12;
+        const widths = pills.map(el => el.offsetWidth);
+        const inputReserve = show ? INPUT_RESERVE + gap : 0;
+
+        const totalAll = widths.reduce((sum, w, i) => sum + w + (i ? gap : 0), 0);
+        if (totalAll + inputReserve <= avail) {
+            setFit(pills.length);
+            setMeasuring(false);
+            return;
+        }
+
+        const reserve = CHIP_RESERVE + gap + inputReserve;
+        let used = 0;
+        let fitCount = 0;
+        for (let i = 0; i < widths.length; i++) {
+            const add = widths[i] + (fitCount ? gap : 0);
+            if (used + add + reserve > avail) break;
+            used += add;
+            fitCount++;
+        }
+        setFit(fitCount);
         setMeasuring(false);
-    }, [collapsed, measuring, count]);
+    }, [measuring, count, show]);
 
     // Re-measure on width changes (absent in jsdom/SSR).
     useLayoutEffect(() => {
-        if (!collapsed) return undefined;
         const body = wrapRef.current?.parentElement;
         if (typeof ResizeObserver === "undefined" || !body) return undefined;
         const observer = new ResizeObserver(() => setMeasuring(true));
         observer.observe(body);
         return () => observer.disconnect();
-    }, [collapsed]);
+    }, []);
+
+    if (count === 0) return null;
 
     const pill = (item: unknown, index: number) => (
         <SelectedItem key={valueField(item)?.toString() ?? index} item={item} />
     );
-
-    if (!collapsed) {
-        return <>{selectedItems.map(pill)}</>;
-    }
 
     const visible = measuring ? selectedItems : selectedItems.slice(0, fit);
     const hidden = count - visible.length;

--- a/moo-ds/src/components/comboBox/ComboBoxPills.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxPills.tsx
@@ -1,0 +1,75 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import { useComboBox } from "./ComboBoxProvider";
+import { ComboBoxSelectedItem as SelectedItem } from "./ComboBoxSelectedItem";
+
+// Renders the multi-select pills. While the dropdown is closed the pills
+// collapse to however many fit on a single row plus a "+N more" chip; when it's
+// open (actively choosing) every pill is shown.
+//
+// To know how many fit, every pill is rendered during a short "measure" pass and
+// their row (offsetTop) is read; the overflow is then dropped and replaced by the
+// chip. A single set of pills is used (no off-screen clone), so the DOM isn't
+// duplicated. Measuring needs real layout, so where it's unavailable (jsdom/SSR)
+// it falls back to showing every pill.
+export const ComboBoxPills = () => {
+
+    const { selectedItems, show, valueField } = useComboBox();
+
+    const wrapRef = useRef<HTMLDivElement>(null);
+    const [fit, setFit] = useState(selectedItems.length);
+    const [measuring, setMeasuring] = useState(true);
+
+    const collapsed = !show && selectedItems.length > 0;
+    const count = selectedItems.length;
+
+    // Re-measure whenever the collapse state or the number of pills changes.
+    useLayoutEffect(() => {
+        if (collapsed) setMeasuring(true);
+    }, [collapsed, count]);
+
+    // Measure pass: with every pill rendered, count the ones on the first row.
+    useLayoutEffect(() => {
+        if (!collapsed || !measuring) return;
+        const wrap = wrapRef.current;
+        if (!wrap) return;
+
+        const pills = Array.from(wrap.querySelectorAll<HTMLElement>(".item"));
+        if (pills.length > 0) {
+            const firstTop = pills[0].offsetTop;
+            const firstRow = pills.filter(p => p.offsetTop <= firstTop + 1).length;
+            // Reserve a slot for the "+N more" chip when there's overflow.
+            setFit(firstRow >= pills.length ? pills.length : Math.max(1, firstRow - 1));
+        }
+        setMeasuring(false);
+    }, [collapsed, measuring, count]);
+
+    // Re-measure on width changes (absent in jsdom/SSR).
+    useLayoutEffect(() => {
+        if (!collapsed) return undefined;
+        const body = wrapRef.current?.parentElement;
+        if (typeof ResizeObserver === "undefined" || !body) return undefined;
+        const observer = new ResizeObserver(() => setMeasuring(true));
+        observer.observe(body);
+        return () => observer.disconnect();
+    }, [collapsed]);
+
+    const pill = (item: unknown, index: number) => (
+        <SelectedItem key={valueField(item)?.toString() ?? index} item={item} />
+    );
+
+    if (!collapsed) {
+        return <>{selectedItems.map(pill)}</>;
+    }
+
+    const visible = measuring ? selectedItems : selectedItems.slice(0, fit);
+    const hidden = count - visible.length;
+
+    return (
+        <div className="cb-pills" ref={wrapRef}>
+            {visible.map(pill)}
+            {!measuring && hidden > 0 && <span className="cb-more">+{hidden} more</span>}
+        </div>
+    );
+};
+
+ComboBoxPills.displayName = "ComboBoxPills";

--- a/moo-ds/src/components/comboBox/ComboBoxProvider.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxProvider.tsx
@@ -49,10 +49,10 @@ export const ComboBoxProvider = <T,>(props: React.PropsWithChildren<ComboBoxProv
         setShow(false);
     }, [props.readonly]);
 
-    const { clearable, creatable, multiSelect, readonly, labelField, valueField, colourField, onAdd, onRemove, onChange, onCreate, createLabel, search, ref } = props;
+    const { clearable, creatable, multiSelect, readonly, labelField, valueField, colourField, onAdd, onRemove, onChange, onCreate, createLabel, search, ref, collapseAfter = 5 } = props;
 
     return (
-        <ComboBoxContext value={{ selectedItems, setSelectedItems, text, setText, items, setItems, newItem, setNewItem, show, setShow, showInput, setShowInput, clear, clearable, creatable, multiSelect, readonly, labelField, valueField, colourField, onAdd, onRemove, onChange, onCreate, createLabel, search, allItems, ref, listId }}>
+        <ComboBoxContext value={{ selectedItems, setSelectedItems, text, setText, items, setItems, newItem, setNewItem, show, setShow, showInput, setShowInput, clear, clearable, creatable, multiSelect, readonly, labelField, valueField, colourField, onAdd, onRemove, onChange, onCreate, createLabel, search, allItems, ref, listId, collapseAfter }}>
             {props.children}
         </ComboBoxContext>
     );
@@ -101,6 +101,7 @@ export interface ComboBoxOptions {
     allItems?: any[];
     ref: React.Ref<HTMLInputElement>;
     listId: string;
+    collapseAfter: number;
 }
 
 export interface ComboBoxProps<TItem> extends RefProps<HTMLInputElement> {
@@ -124,5 +125,11 @@ export interface ComboBoxProps<TItem> extends RefProps<HTMLInputElement> {
     readonly?: boolean;
     tabIndex?: number;
     createLabel?: (input: string) => string;
+    /**
+     * For multi-select: collapse the selected pills to the first N plus a
+     * "+X more" chip while the control is inactive, so many selections don't
+     * grow the box. Clicking anywhere expands to all pills. Defaults to 5.
+     */
+    collapseAfter?: number;
 }
 

--- a/moo-ds/src/components/comboBox/ComboBoxProvider.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxProvider.tsx
@@ -49,10 +49,10 @@ export const ComboBoxProvider = <T,>(props: React.PropsWithChildren<ComboBoxProv
         setShow(false);
     }, [props.readonly]);
 
-    const { clearable, creatable, multiSelect, readonly, labelField, valueField, colourField, onAdd, onRemove, onChange, onCreate, createLabel, search, ref, collapseAfter = 5 } = props;
+    const { clearable, creatable, multiSelect, readonly, labelField, valueField, colourField, onAdd, onRemove, onChange, onCreate, createLabel, search, ref } = props;
 
     return (
-        <ComboBoxContext value={{ selectedItems, setSelectedItems, text, setText, items, setItems, newItem, setNewItem, show, setShow, showInput, setShowInput, clear, clearable, creatable, multiSelect, readonly, labelField, valueField, colourField, onAdd, onRemove, onChange, onCreate, createLabel, search, allItems, ref, listId, collapseAfter }}>
+        <ComboBoxContext value={{ selectedItems, setSelectedItems, text, setText, items, setItems, newItem, setNewItem, show, setShow, showInput, setShowInput, clear, clearable, creatable, multiSelect, readonly, labelField, valueField, colourField, onAdd, onRemove, onChange, onCreate, createLabel, search, allItems, ref, listId }}>
             {props.children}
         </ComboBoxContext>
     );
@@ -101,7 +101,6 @@ export interface ComboBoxOptions {
     allItems?: any[];
     ref: React.Ref<HTMLInputElement>;
     listId: string;
-    collapseAfter: number;
 }
 
 export interface ComboBoxProps<TItem> extends RefProps<HTMLInputElement> {
@@ -125,11 +124,5 @@ export interface ComboBoxProps<TItem> extends RefProps<HTMLInputElement> {
     readonly?: boolean;
     tabIndex?: number;
     createLabel?: (input: string) => string;
-    /**
-     * For multi-select: collapse the selected pills to the first N plus a
-     * "+X more" chip while the control is inactive, so many selections don't
-     * grow the box. Clicking anywhere expands to all pills. Defaults to 5.
-     */
-    collapseAfter?: number;
 }
 

--- a/moo-ds/src/components/comboBox/__tests__/ComboBox.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBox.test.tsx
@@ -230,7 +230,10 @@ describe('ComboBox', () => {
     });
   });
 
-  describe('collapse (multi-select)', () => {
+  describe('multi-select collapse', () => {
+    // The pixel-level "how many fit one row" measurement needs real layout, so
+    // it is verified in the browser. jsdom has no layout, so these assert the
+    // collapse *structure* and state transitions instead.
     const manyItems: TestItem[] = Array.from({ length: 8 }, (_, i) => ({ id: i + 1, name: `Item ${i + 1}` }));
     const manyProps = {
       items: manyItems,
@@ -239,42 +242,40 @@ describe('ComboBox', () => {
       multiSelect: true,
     };
 
-    it('collapses to the first N pills + a "+X more" chip when inactive', () => {
+    it('wraps the pills for measurement while the dropdown is closed', () => {
       const { container } = render(<ComboBox {...manyProps} selectedItems={manyItems} />);
 
-      // Default collapseAfter is 5 -> 5 pills, +3 more.
-      expect(container.querySelectorAll('.body .item')).toHaveLength(5);
-      expect(screen.getByText('+3 more')).toBeInTheDocument();
-      expect(screen.queryByText('Item 8')).not.toBeInTheDocument();
+      expect(container.querySelector('.cb-pills')).toBeInTheDocument();
+    });
+
+    it('hides the input while collapsed (pills stand in for it)', () => {
+      const { container } = render(<ComboBox {...manyProps} selectedItems={manyItems} />);
+
+      expect(container.querySelector('.body input')).toHaveAttribute('hidden');
+    });
+
+    it('renders each selected pill exactly once (no measurement clone)', () => {
+      render(<ComboBox {...manyProps} selectedItems={manyItems} />);
+
+      // Would throw if a hidden clone duplicated the label.
       expect(screen.getByText('Item 1')).toBeInTheDocument();
+      expect(screen.getByText('Item 8')).toBeInTheDocument();
     });
 
-    it('respects the collapseAfter prop', () => {
-      const { container } = render(<ComboBox {...manyProps} collapseAfter={3} selectedItems={manyItems} />);
-
-      expect(container.querySelectorAll('.body .item')).toHaveLength(3);
-      expect(screen.getByText('+5 more')).toBeInTheDocument();
-    });
-
-    it('does not collapse when at or below the threshold', () => {
-      render(<ComboBox {...manyProps} selectedItems={manyItems.slice(0, 4)} />);
-
-      expect(screen.queryByText(/more$/)).not.toBeInTheDocument();
-    });
-
-    it('expands to all pills when activated', () => {
+    it('expands (all pills, no wrapper) and shows the input when opened', () => {
       const { container } = render(<ComboBox {...manyProps} selectedItems={manyItems} />);
 
       fireEvent.click(container.querySelector('.combo-box')!);
 
-      expect(container.querySelectorAll('.body .item')).toHaveLength(8);
-      expect(screen.queryByText('+3 more')).not.toBeInTheDocument();
-      expect(screen.getByText('Item 8')).toBeInTheDocument();
+      expect(container.querySelector('.cb-pills')).not.toBeInTheDocument();
+      expect(container.querySelector('.body input')).not.toHaveAttribute('hidden');
+      expect(container.querySelectorAll('.body > .item')).toHaveLength(8);
     });
 
-    it('does not collapse a single-select combo box', () => {
-      render(<ComboBox {...defaultProps} selectedItems={[testItems[0]]} />);
-      expect(screen.queryByText(/more$/)).not.toBeInTheDocument();
+    it('does not wrap pills for a single-select combo box', () => {
+      const { container } = render(<ComboBox {...defaultProps} selectedItems={[testItems[0]]} />);
+
+      expect(container.querySelector('.cb-pills')).not.toBeInTheDocument();
     });
   });
 

--- a/moo-ds/src/components/comboBox/__tests__/ComboBox.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBox.test.tsx
@@ -242,16 +242,24 @@ describe('ComboBox', () => {
       multiSelect: true,
     };
 
-    it('wraps the pills for measurement while the dropdown is closed', () => {
+    it('wraps the pills in the measurement container', () => {
       const { container } = render(<ComboBox {...manyProps} selectedItems={manyItems} />);
 
       expect(container.querySelector('.cb-pills')).toBeInTheDocument();
     });
 
-    it('hides the input while collapsed (pills stand in for it)', () => {
+    it('hides the input while the dropdown is closed (pills stand in for it)', () => {
       const { container } = render(<ComboBox {...manyProps} selectedItems={manyItems} />);
 
       expect(container.querySelector('.body input')).toHaveAttribute('hidden');
+    });
+
+    it('shows the input when the dropdown is opened', () => {
+      const { container } = render(<ComboBox {...manyProps} selectedItems={manyItems} />);
+
+      fireEvent.click(container.querySelector('.combo-box')!);
+
+      expect(container.querySelector('.body input')).not.toHaveAttribute('hidden');
     });
 
     it('renders each selected pill exactly once (no measurement clone)', () => {
@@ -262,17 +270,13 @@ describe('ComboBox', () => {
       expect(screen.getByText('Item 8')).toBeInTheDocument();
     });
 
-    it('expands (all pills, no wrapper) and shows the input when opened', () => {
+    it('shows every pill when layout cannot be measured (fallback)', () => {
       const { container } = render(<ComboBox {...manyProps} selectedItems={manyItems} />);
 
-      fireEvent.click(container.querySelector('.combo-box')!);
-
-      expect(container.querySelector('.cb-pills')).not.toBeInTheDocument();
-      expect(container.querySelector('.body input')).not.toHaveAttribute('hidden');
-      expect(container.querySelectorAll('.body > .item')).toHaveLength(8);
+      expect(container.querySelectorAll('.cb-pills .item')).toHaveLength(8);
     });
 
-    it('does not wrap pills for a single-select combo box', () => {
+    it('does not render the pills container for a single-select combo box', () => {
       const { container } = render(<ComboBox {...defaultProps} selectedItems={[testItems[0]]} />);
 
       expect(container.querySelector('.cb-pills')).not.toBeInTheDocument();

--- a/moo-ds/src/components/comboBox/__tests__/ComboBox.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBox.test.tsx
@@ -229,4 +229,63 @@ describe('ComboBox', () => {
       expect(container.querySelector('.combo-box')).toBeInTheDocument();
     });
   });
+
+  describe('collapse (multi-select)', () => {
+    const manyItems: TestItem[] = Array.from({ length: 8 }, (_, i) => ({ id: i + 1, name: `Item ${i + 1}` }));
+    const manyProps = {
+      items: manyItems,
+      labelField: (item: TestItem) => item.name,
+      valueField: (item: TestItem) => item.id,
+      multiSelect: true,
+    };
+
+    it('collapses to the first N pills + a "+X more" chip when inactive', () => {
+      const { container } = render(<ComboBox {...manyProps} selectedItems={manyItems} />);
+
+      // Default collapseAfter is 5 -> 5 pills, +3 more.
+      expect(container.querySelectorAll('.body .item')).toHaveLength(5);
+      expect(screen.getByText('+3 more')).toBeInTheDocument();
+      expect(screen.queryByText('Item 8')).not.toBeInTheDocument();
+      expect(screen.getByText('Item 1')).toBeInTheDocument();
+    });
+
+    it('respects the collapseAfter prop', () => {
+      const { container } = render(<ComboBox {...manyProps} collapseAfter={3} selectedItems={manyItems} />);
+
+      expect(container.querySelectorAll('.body .item')).toHaveLength(3);
+      expect(screen.getByText('+5 more')).toBeInTheDocument();
+    });
+
+    it('does not collapse when at or below the threshold', () => {
+      render(<ComboBox {...manyProps} selectedItems={manyItems.slice(0, 4)} />);
+
+      expect(screen.queryByText(/more$/)).not.toBeInTheDocument();
+    });
+
+    it('expands to all pills when activated', () => {
+      const { container } = render(<ComboBox {...manyProps} selectedItems={manyItems} />);
+
+      fireEvent.click(container.querySelector('.combo-box')!);
+
+      expect(container.querySelectorAll('.body .item')).toHaveLength(8);
+      expect(screen.queryByText('+3 more')).not.toBeInTheDocument();
+      expect(screen.getByText('Item 8')).toBeInTheDocument();
+    });
+
+    it('does not collapse a single-select combo box', () => {
+      render(<ComboBox {...defaultProps} selectedItems={[testItems[0]]} />);
+      expect(screen.queryByText(/more$/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('focus on click', () => {
+    it('focuses the input when the control is clicked', () => {
+      const { container } = render(<ComboBox {...defaultProps} multiSelect selectedItems={[testItems[0]]} />);
+
+      fireEvent.click(container.querySelector('.combo-box')!);
+
+      const input = container.querySelector('input');
+      expect(document.activeElement).toBe(input);
+    });
+  });
 });

--- a/moo-ds/src/css/components/_combo-box.css
+++ b/moo-ds/src/css/components/_combo-box.css
@@ -48,10 +48,17 @@
         flex-wrap: wrap;
         flex: 1 1 100px;
         min-width: 100px;
-        /* Cap the pill area to a few rows; excess scrolls internally so a large
-           selection can't grow the control unbounded. */
+        position: relative;
+        /* Cap the pill area to a few rows while the dropdown is open (all pills
+           shown); excess scrolls internally so it can't grow unbounded. */
         max-height: 7.5rem;
         overflow-y: auto;
+    }
+
+    /* The pills wrapper participates directly in the body's flex layout so pill
+       rows can be measured, without adding a box of its own. */
+    .cb-pills {
+        display: contents;
     }
 
     .cb-more {

--- a/moo-ds/src/css/components/_combo-box.css
+++ b/moo-ds/src/css/components/_combo-box.css
@@ -34,9 +34,7 @@
 
     >div {
         display: flex;
-        /* Pin the controls to the top so they don't float to the vertical
-           middle when the pill area wraps to several rows. */
-        align-items: flex-start;
+        align-items: center;
         flex-direction: row;
         flex-wrap: wrap;
         justify-content: flex-end;
@@ -116,6 +114,10 @@
         display: flex;
         align-items: center;
         justify-self: flex-end;
+        /* Pin to the top so the controls don't float to the vertical middle when
+           the pill area wraps to several rows. The body stays centred, which the
+           absolutely-positioned single-select value depends on. */
+        align-self: flex-start;
 
         div {
             margin: var(--input-padding-v) 0;

--- a/moo-ds/src/css/components/_combo-box.css
+++ b/moo-ds/src/css/components/_combo-box.css
@@ -34,7 +34,9 @@
 
     >div {
         display: flex;
-        align-items: center;
+        /* Pin the controls to the top so they don't float to the vertical
+           middle when the pill area wraps to several rows. */
+        align-items: flex-start;
         flex-direction: row;
         flex-wrap: wrap;
         justify-content: flex-end;
@@ -48,6 +50,29 @@
         flex-wrap: wrap;
         flex: 1 1 100px;
         min-width: 100px;
+        /* Cap the pill area to a few rows; excess scrolls internally so a large
+           selection can't grow the control unbounded. */
+        max-height: 7.5rem;
+        overflow-y: auto;
+    }
+
+    .cb-more {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.35em 0.7em;
+        font-size: 0.8rem;
+        font-weight: 500;
+        line-height: 1;
+        border-radius: 50rem;
+        background: color-mix(in srgb, var(--body-colour) 12%, transparent);
+        color: var(--body-colour-dim);
+        cursor: pointer;
+        white-space: nowrap;
+        user-select: none;
+
+        &:hover {
+            color: var(--body-colour);
+        }
     }
 
     input {

--- a/moo-ds/src/css/components/_combo-box.css
+++ b/moo-ds/src/css/components/_combo-box.css
@@ -45,14 +45,14 @@
         display: flex;
         gap: 0.75rem;
         align-items: center;
-        flex-wrap: wrap;
+        /* The pill area is always a single row: the pills are measured down to
+           what fits and the overflow becomes a "+N more" chip, so the control
+           never grows past one line. nowrap + overflow guard against any
+           measurement lag. */
+        flex-wrap: nowrap;
+        overflow: hidden;
         flex: 1 1 100px;
         min-width: 100px;
-        position: relative;
-        /* Cap the pill area to a few rows while the dropdown is open (all pills
-           shown); excess scrolls internally so it can't grow unbounded. */
-        max-height: 7.5rem;
-        overflow-y: auto;
     }
 
     /* The pills wrapper participates directly in the body's flex layout so pill


### PR DESCRIPTION
Improves the multi-select ComboBox for the many-selections case (per the design discussion): it was growing to multiple rows and the clear/chevron controls floated to the vertical middle.

## Changes

- **Always one line.** The selected pills never wrap. `ComboBoxPills` measures how many pills fit the row and shows the rest as a muted **"+N more"** chip; the body is `flex-wrap: nowrap` + `overflow: hidden`. Room is reserved for the chip and, when the dropdown is open, the text input — so the control stays a single line in every state. Managing the full set happens through the dropdown.
- **Click anywhere focuses the input** (except a remove-x / clear-x, which already stop propagation). The chevron toggles the dropdown as a distinct control.
- **Controls pinned to the top-right** instead of vertically centred.
- Fixed a single-select regression where the absolutely-positioned value jumped to the top (pin only the controls, keep the row centred).

## Implementation notes

- The fit is measured from real layout (every pill rendered for one pass, widths read, overflow dropped) using a single set of pills (no clone, so no duplicated DOM/text) and a `display: contents` wrapper. A `ResizeObserver` re-measures on width change; where layout is unavailable (jsdom/SSR) it falls back to showing every pill.
- The chip/input reserves are approximate constants at the top of `ComboBoxPills` (`CHIP_RESERVE` / `INPUT_RESERVE`), slightly generous so it never overflows.

## Demo & tests

- New demoo `/combo-box` route (many selections, in-a-table).
- Tests cover the state transitions (pills wrapped for measurement, input hidden closed / shown open, single-select unaffected, focus-on-click). The pixel-level fit needs real layout so it was verified in the browser rather than jsdom.
- **1283 moo-ds tests pass**; type-check + build clean.

## Note
Branched off `main`, so it doesn't include the lint fix in #636 — `npm run lint` won't run on this branch until that merges, but nothing here touches the files #636 changed, and CI (build only) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)