### PR TITLE
fix(auth): stop dashboard queries racing the MSAL auth window

### DIFF
--- a/moo-app/src/MooApp.tsx
+++ b/moo-app/src/MooApp.tsx
@@ -60,7 +60,11 @@ export const MooApp: React.FC<PropsWithChildren<MooAppProps>> = ({ router, clien
 
   useEffect(() => {
     const onAuthRecovered = () => {
-      queryClient.invalidateQueries();
+      // Only refetch queries that actually failed. Recovery fires on silent token
+      // renewals too (which can happen routinely), so invalidating everything would
+      // cause a refetch storm; scoping to errored queries makes it a no-op unless a
+      // request was cancelled during an auth window (see login/msal.ts, Login gate).
+      queryClient.invalidateQueries({ predicate: (query) => query.state.status === "error" });
     };
 
     window.addEventListener(AUTH_RECOVERED_EVENT, onAuthRecovered);

--- a/moo-app/src/login/Login.tsx
+++ b/moo-app/src/login/Login.tsx
@@ -1,5 +1,5 @@
-import { InteractionType } from "@azure/msal-browser";
-import { useIsAuthenticated, useMsalAuthentication } from "@azure/msal-react";
+import { InteractionStatus, InteractionType } from "@azure/msal-browser";
+import { useIsAuthenticated, useMsal, useMsalAuthentication } from "@azure/msal-react";
 import { type PropsWithChildren, type ReactNode } from "react";
 import { loginRequest } from "./msal";
 
@@ -11,8 +11,17 @@ export const Login: React.FC<PropsWithChildren<LoginProps>> = ({children, authFa
 
   useMsalAuthentication(InteractionType.Redirect, loginRequest);
   const isAuthenticated = useIsAuthenticated();
+  const { inProgress } = useMsal();
 
-  if (!isAuthenticated) return <>{authFallback ?? null}</>;
+  // Gate on BOTH an authenticated account and MSAL being idle. On a re-auth
+  // reload a cached account makes isAuthenticated true immediately, but MSAL is
+  // still mid-flight (handling the redirect response / ssoSilent). Rendering
+  // data-fetching children during that window races the access-token interceptor:
+  // acquireTokenSilent throws interaction_in_progress, the request is cancelled
+  // before it is sent, and with the QueryClient's retry:false the query stays
+  // errored (e.g. dashboard widgets showing "Unable to load"). Waiting for
+  // InteractionStatus.None lets the token be acquirable before the first request.
+  if (!isAuthenticated || inProgress !== InteractionStatus.None) return <>{authFallback ?? null}</>;
 
   return <>{children}</>;
 }

--- a/moo-app/src/login/__tests__/Login.test.tsx
+++ b/moo-app/src/login/__tests__/Login.test.tsx
@@ -5,6 +5,7 @@ import { Login } from '../Login';
 // Mock MSAL authentication hook
 const mockUseMsalAuthentication = vi.fn();
 const mockUseIsAuthenticated = vi.fn();
+const mockUseMsal = vi.fn();
 
 vi.mock('@azure/msal-react', () => ({
   useMsalAuthentication: (interactionType: any, request: any) => {
@@ -16,6 +17,7 @@ vi.mock('@azure/msal-react', () => ({
     };
   },
   useIsAuthenticated: () => mockUseIsAuthenticated(),
+  useMsal: () => mockUseMsal(),
 }));
 
 vi.mock('@azure/msal-browser', () => ({
@@ -23,6 +25,15 @@ vi.mock('@azure/msal-browser', () => ({
     Redirect: 'redirect',
     Popup: 'popup',
     Silent: 'silent',
+  },
+  InteractionStatus: {
+    None: 'none',
+    Startup: 'startup',
+    Login: 'login',
+    Logout: 'logout',
+    AcquireToken: 'acquireToken',
+    SsoSilent: 'ssoSilent',
+    HandleRedirect: 'handleRedirect',
   },
 }));
 
@@ -35,6 +46,9 @@ describe('Login', () => {
     mockUseMsalAuthentication.mockClear();
     mockUseIsAuthenticated.mockClear();
     mockUseIsAuthenticated.mockReturnValue(true);
+    // Default to MSAL idle so existing "authenticated" cases render children.
+    mockUseMsal.mockReset();
+    mockUseMsal.mockReturnValue({ inProgress: 'none' });
   });
 
   describe('rendering', () => {
@@ -60,6 +74,37 @@ describe('Login', () => {
 
       expect(screen.queryByTestId('child')).not.toBeInTheDocument();
       expect(container.innerHTML).toBe('');
+    });
+
+    it('does not render children while an MSAL interaction is in progress, even when authenticated', () => {
+      // A cached account makes isAuthenticated true immediately on a re-auth
+      // reload, but MSAL is still mid-flight. Rendering data-fetching children
+      // now races the token interceptor (acquireTokenSilent -> interaction_in_progress
+      // -> cancelled request -> permanently errored query with retry:false).
+      mockUseIsAuthenticated.mockReturnValue(true);
+      mockUseMsal.mockReturnValue({ inProgress: 'handleRedirect' });
+
+      render(
+        <Login authFallback={<div data-testid="loading">Loading...</div>}>
+          <div data-testid="child">Protected Content</div>
+        </Login>
+      );
+
+      expect(screen.queryByTestId('child')).not.toBeInTheDocument();
+      expect(screen.getByTestId('loading')).toBeInTheDocument();
+    });
+
+    it('renders children once the interaction completes (inProgress None)', () => {
+      mockUseIsAuthenticated.mockReturnValue(true);
+      mockUseMsal.mockReturnValue({ inProgress: 'none' });
+
+      render(
+        <Login>
+          <div data-testid="child">Protected Content</div>
+        </Login>
+      );
+
+      expect(screen.getByTestId('child')).toBeInTheDocument();
     });
 
     it('renders multiple children', () => {

--- a/moo-app/src/login/__tests__/msal.test.ts
+++ b/moo-app/src/login/__tests__/msal.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
 
+// Shared holder so the hoisted mock can hand the registered MSAL event callback
+// back to the test body (getMsalInstance registers it once, on the singleton).
+const eventCallback = vi.hoisted(() => ({ current: undefined as ((event: any) => void) | undefined }));
+
 // Mock only the instance factory so getMsalInstance can be exercised without
 // creating a real MSAL instance; everything else (LogLevel, enums) stays real.
 vi.mock('@azure/msal-browser', async (importActual) => {
@@ -8,7 +12,7 @@ vi.mock('@azure/msal-browser', async (importActual) => {
     ...actual,
     createStandardPublicClientApplication: vi.fn(async (config: any): Promise<any> => ({
       __config: config,
-      addEventCallback: vi.fn(),
+      addEventCallback: vi.fn((cb: (event: any) => void) => { eventCallback.current = cb; return 'callback-id'; }),
       getAllAccounts: (): any[] => [],
       getActiveAccount: (): any => null,
       setActiveAccount: vi.fn(),
@@ -16,7 +20,7 @@ vi.mock('@azure/msal-browser', async (importActual) => {
   };
 });
 
-import getMsalInstance, { loginRequest, apiRequest } from '../msal';
+import getMsalInstance, { AUTH_RECOVERED_EVENT, loginRequest, apiRequest } from '../msal';
 import * as msalBrowser from '@azure/msal-browser';
 
 describe('getMsalInstance configuration', () => {
@@ -31,6 +35,45 @@ describe('getMsalInstance configuration', () => {
     const config = createFn.mock.calls[0][0] as any;
     expect(config.auth.clientId).toBe('client-abc');
     expect(config.auth.authority).toBe('https://login.microsoftonline.com/custom-tenant');
+  });
+});
+
+describe('auth-recovered event', () => {
+  // Fire an event through the callback getMsalInstance registered on the instance.
+  const fire = async (event: any) => {
+    await getMsalInstance('client-abc');
+    expect(eventCallback.current).toBeDefined();
+    eventCallback.current!(event);
+  };
+
+  it('dispatches AUTH_RECOVERED_EVENT on a silent ACQUIRE_TOKEN_SUCCESS', async () => {
+    const listener = vi.fn();
+    window.addEventListener(AUTH_RECOVERED_EVENT, listener);
+    try {
+      await fire({
+        eventType: msalBrowser.EventType.ACQUIRE_TOKEN_SUCCESS,
+        interactionType: msalBrowser.InteractionType.Silent,
+        payload: { account: { homeAccountId: 'a' } },
+      });
+      expect(listener).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener(AUTH_RECOVERED_EVENT, listener);
+    }
+  });
+
+  it('dispatches AUTH_RECOVERED_EVENT on a redirect ACQUIRE_TOKEN_SUCCESS', async () => {
+    const listener = vi.fn();
+    window.addEventListener(AUTH_RECOVERED_EVENT, listener);
+    try {
+      await fire({
+        eventType: msalBrowser.EventType.ACQUIRE_TOKEN_SUCCESS,
+        interactionType: msalBrowser.InteractionType.Redirect,
+        payload: { account: { homeAccountId: 'a' } },
+      });
+      expect(listener).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener(AUTH_RECOVERED_EVENT, listener);
+    }
   });
 });
 

--- a/moo-app/src/login/msal.ts
+++ b/moo-app/src/login/msal.ts
@@ -150,8 +150,15 @@ const getMsalInstance = async (clientId: string, options?: MsalOptions): Promise
         }
         else if (
             event.eventType === msal.EventType.ACQUIRE_TOKEN_SUCCESS &&
-            (event.interactionType === msal.InteractionType.Redirect || event.interactionType === msal.InteractionType.Popup)
+            (event.interactionType === msal.InteractionType.Redirect ||
+                event.interactionType === msal.InteractionType.Popup ||
+                event.interactionType === msal.InteractionType.Silent)
         ) {
+            // Include Silent: when auth is brought back up to date by a background
+            // silent token renewal (not an interactive redirect/popup), any query
+            // that errored during the auth window must still be recovered. The
+            // listener (MooApp) only refetches errored queries, so firing this on
+            // every silent success is a no-op when nothing is stuck.
             window.dispatchEvent(new Event(AUTH_RECOVERED_EVENT));
         }
     });


### PR DESCRIPTION
## Problem

On a first load after a while (token expired but account still cached), the app goes through the MSAL re-auth flow and reloads, then dashboard widgets show **"Unable to load this widget"** with **no `/api` calls in the network trace at all**.

Root cause is a race, made permanent by two design choices:

1. A cached account makes `useIsAuthenticated()` return **true immediately**, but MSAL is still mid-flight (handling the redirect response / doing an `ssoSilent` renewal).
2. `Login` rendered its data-fetching children during that window. The access-token interceptor called `acquireTokenSilent`, which threw `interaction_in_progress`, and the interceptor threw a `CanceledError` — **the request is never sent**.
3. The QueryClient is `retry: false`, so the query lands in a **permanent** error state → `WidgetError`.
4. The only recovery (`AUTH_RECOVERED_EVENT → invalidateQueries`) fired only for **Redirect/Popup** token success, **not silent** — so when auth completed via the background silent iframe, nothing recovered.

## Fix (belt-and-braces)

- **`Login`** now gates on `inProgress === InteractionStatus.None` as well as `isAuthenticated`, so data-fetching children mount only once a token is acquirable.
- **`msal.ts`** now dispatches `AUTH_RECOVERED_EVENT` on a **silent** `ACQUIRE_TOKEN_SUCCESS` too, so any query that still errors during a background silent renewal is recovered.
- **`MooApp`** recovery listener now invalidates **only errored queries** (`predicate: q => q.state.status === "error"`), so firing recovery on every silent success is a no-op unless something is actually stuck — no refetch storm.

## Tests

- `Login`: does not render children while `inProgress !== None`; renders once idle.
- `msal`: dispatches `AUTH_RECOVERED_EVENT` on silent (and redirect) `ACQUIRE_TOKEN_SUCCESS`.

Full suite: 237 passing. Lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)