### PR TITLE
feat(combo-box): checklist multi-select and in-place pill expansion

### DIFF
--- a/demoo/src/App.css
+++ b/demoo/src/App.css
@@ -65,6 +65,12 @@
   color: var(--muted-colour, #6c757d);
 }
 
+/* Keep the ComboBox demos narrow so pill overflow ("+N more") is easy to
+   trigger without shrinking the whole window. */
+.cb-demo {
+  max-width: 26rem;
+}
+
 .section.buttons {
   display: flex;
   gap: 1rem;

--- a/demoo/src/routes/ComboBox.tsx
+++ b/demoo/src/routes/ComboBox.tsx
@@ -1,5 +1,5 @@
 import { Page } from "@andrewmclachlan/moo-app";
-import { ComboBox, Section, SectionTable } from "@andrewmclachlan/moo-ds";
+import { ComboBox, Section, SectionTable, TagPanel } from "@andrewmclachlan/moo-ds";
 import { useMemo, useState } from "react";
 
 type Tag = { id: number; text: string; colour: string };
@@ -17,6 +17,7 @@ export const ComboBoxPage = () => {
     const [many, setMany] = useState<Tag[]>(() => items.slice(0, 8));
     const [few, setFew] = useState<Tag[]>(() => items.slice(4, 6));
     const [inCell, setInCell] = useState<Tag[]>(() => items.slice(0, 7));
+    const [chromeless, setChromeless] = useState<Tag[]>(() => items.slice(2, 5));
 
     const common = {
         items,
@@ -26,6 +27,7 @@ export const ComboBoxPage = () => {
         multiSelect: true,
         clearable: true,
         placeholder: "Select...",
+        className: "cb-demo",
     } as const;
 
     return (
@@ -34,15 +36,27 @@ export const ComboBoxPage = () => {
             <Section title="Many selections" header="Many selections (collapse to one row)" headerSize={4}>
                 <p>
                     While the dropdown is closed, the pills collapse to however many fit on a single
-                    row plus a &ldquo;+N more&rdquo; chip. Click anywhere (except a remove &times;) to
-                    open it &mdash; that expands to every pill and focuses the input. Resize the window
-                    to see the fit re-measure.
+                    row plus a &ldquo;+N more&rdquo; chip. Click that chip to expand every pill in
+                    place (it becomes &ldquo;show less&rdquo;); resize the window to see the fit
+                    re-measure. Open the dropdown and the selected items stay in the list &mdash;
+                    checked and pinned to the top &mdash; so you can see and untick any of them,
+                    including the ones hidden behind &ldquo;+N more&rdquo;.
                 </p>
                 <ComboBox {...common} selectedItems={many} onChange={setMany} />
             </Section>
 
             <Section title="Few selections" header="Few selections (all fit, no chip)" headerSize={4}>
                 <ComboBox {...common} selectedItems={few} onChange={setFew} />
+            </Section>
+
+            <Section title="Chromeless" header="Chromeless until clicked (TagPanel)" headerSize={4}>
+                <p>
+                    <code>TagPanel</code> wraps the ComboBox and toggles its <code>readonly</code>{" "}
+                    prop: while unfocused the chrome disappears &mdash; no border, background, or
+                    controls, just the pills. Click anywhere on it to get the full editable
+                    ComboBox back; click away (or press Enter/Tab) to collapse it again.
+                </p>
+                <TagPanel {...common} selectedItems={chromeless} onChange={setChromeless} />
             </Section>
 
             <SectionTable header="In a table" headerSize={4} striped hover>

--- a/moo-ds/src/components/comboBox/ComboBoxItem.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxItem.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import { useComboBox } from "./ComboBoxProvider";
 
 export const ComobBoxItem = <T,>(props: ComboBoxItemProps<T>) => {
@@ -27,7 +28,16 @@ export const ComobBoxItem = <T,>(props: ComboBoxItemProps<T>) => {
 
     // tabIndex 0 keeps options reachable by keyboard (Tab from the input) so the
     // Enter/Space handler is usable, without the positive-tabIndex anti-pattern.
-    return (<li role="option" onClick={click} onKeyDown={keyDown} tabIndex={0}>{props.label ?? labelField(props.item)}</li>);
+    // When `selected` is set (multi-select), the row reads as a checkbox: a tick
+    // marks it and aria-selected exposes the state to assistive tech.
+    return (
+        <li role="option" aria-selected={props.selected} onClick={click} onKeyDown={keyDown} tabIndex={0} className={classNames({ "cb-option": props.selected !== undefined, selected: props.selected })}>
+            {props.selected !== undefined &&
+                <svg className="cb-check" height="14" width="14" viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m3 8 3.5 3.5L13 4.5" /></svg>
+            }
+            <span className="cb-option-label">{props.label ?? labelField(props.item)}</span>
+        </li>
+    );
 }
 
 ComobBoxItem.displayName = "ComboBoxItem";
@@ -36,4 +46,6 @@ export interface ComboBoxItemProps<TItem> {
     onSelected: (item: TItem) => void;
     label?: string;
     item: TItem;
+    /** Multi-select only: renders the row as a checkbox with a tick when true. */
+    selected?: boolean;
 }

--- a/moo-ds/src/components/comboBox/ComboBoxList.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxList.tsx
@@ -3,23 +3,36 @@ import { useComboBox } from "./ComboBoxProvider";
 
 export const ComboBoxList = () => {
 
-    const { creatable, items, multiSelect, onAdd, onChange, onCreate, show, setShow, newItem, selectedItems, setSelectedItems, setText, text, valueField, listId } = useComboBox();
+    const { creatable, items, multiSelect, onAdd, onRemove, onChange, onCreate, show, setShow, newItem, selectedItems, setSelectedItems, setText, text, valueField, listId } = useComboBox();
 
     if (!show) return null;
 
+    const isSelected = (item: any) => selectedItems.some(i => valueField(i) === valueField(item));
+
     const onItemSelected = (item: any) => {
 
-        const newSelectedItems = multiSelect ? [...selectedItems, item] : [item];
-
-        if (multiSelect) {
-            onAdd?.(item);
+        // Single-select: pick and close, as before.
+        if (!multiSelect) {
+            const newSelectedItems = [item];
+            setSelectedItems(newSelectedItems);
+            onChange?.(newSelectedItems);
+            setShow(false);
+            setText("");
+            return;
         }
+
+        // Multi-select: the row is a checkbox. Toggle it and keep the dropdown
+        // open so the user can pick several. The text filter is left intact.
+        const selected = isSelected(item);
+        const newSelectedItems = selected
+            ? selectedItems.filter(i => valueField(i) !== valueField(item))
+            : [...selectedItems, item];
+
+        if (selected) onRemove?.(item);
+        else onAdd?.(item);
 
         setSelectedItems(newSelectedItems);
         onChange?.(newSelectedItems);
-
-        setShow(false);
-        setText("");
     }
 
     const onItemCreated = () => {
@@ -28,10 +41,17 @@ export const ComboBoxList = () => {
         setShow(false);
     }
 
+    // Multi-select pins the checked items to the top so "see everything I've
+    // picked" is answered by just opening the list. Stable sort preserves the
+    // original order within each group.
+    const displayItems = multiSelect
+        ? [...items].sort((a, b) => Number(isSelected(b)) - Number(isSelected(a)))
+        : items;
+
     return (
         <ol className="cb-list" id={listId} role="listbox">
-            {items.map((i) =>
-                <ComobBoxItem key={valueField(i)} onSelected={onItemSelected} item={i} />
+            {displayItems.map((i) =>
+                <ComobBoxItem key={valueField(i)} onSelected={onItemSelected} item={i} selected={multiSelect ? isSelected(i) : undefined} />
             )}
             {creatable && newItem &&
                 <ComobBoxItem onSelected={onItemCreated} item={newItem} label={newItem.label} />

--- a/moo-ds/src/components/comboBox/ComboBoxPills.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxPills.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { type MouseEvent, useLayoutEffect, useRef, useState } from "react";
 import { useComboBox } from "./ComboBoxProvider";
 import { ComboBoxSelectedItem as SelectedItem } from "./ComboBoxSelectedItem";
 
@@ -22,8 +22,19 @@ export const ComboBoxPills = () => {
     const wrapRef = useRef<HTMLDivElement>(null);
     const [fit, setFit] = useState(selectedItems.length);
     const [measuring, setMeasuring] = useState(true);
+    const [expanded, setExpanded] = useState(false);
 
     const count = selectedItems.length;
+
+    // Expansion only applies while the dropdown is closed: once it opens, the
+    // list is the place to review selections, so the pills stay on one line.
+    const expandedActive = expanded && !show;
+
+    // Collapse the expanded pills whenever the dropdown opens, so reopening the
+    // closed control doesn't spring back to the multi-line view.
+    useLayoutEffect(() => {
+        if (show) setExpanded(false);
+    }, [show]);
 
     // Re-measure when the pills or the open state (which reserves input room) change.
     useLayoutEffect(() => {
@@ -87,13 +98,30 @@ export const ComboBoxPills = () => {
         <SelectedItem key={valueField(item)?.toString() ?? index} item={item} />
     );
 
+    // The chip stops propagation so toggling the pill view doesn't also open the
+    // dropdown (a click anywhere else in the control does).
+    const toggleExpanded = (e: MouseEvent) => {
+        e.stopPropagation();
+        setExpanded(v => !v);
+    };
+
+    // Expanded: every pill, wrapped over as many rows as needed, plus "show less".
+    if (expandedActive) {
+        return (
+            <div className="cb-pills expanded" ref={wrapRef}>
+                {selectedItems.map(pill)}
+                <button type="button" className="cb-more" onClick={toggleExpanded}>show less</button>
+            </div>
+        );
+    }
+
     const visible = measuring ? selectedItems : selectedItems.slice(0, fit);
     const hidden = count - visible.length;
 
     return (
         <div className="cb-pills" ref={wrapRef}>
             {visible.map(pill)}
-            {!measuring && hidden > 0 && <span className="cb-more">+{hidden} more</span>}
+            {!measuring && hidden > 0 && <button type="button" className="cb-more" onClick={toggleExpanded}>+{hidden} more</button>}
         </div>
     );
 };

--- a/moo-ds/src/components/comboBox/ComboBoxProvider.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxProvider.tsx
@@ -16,12 +16,13 @@ export const ComboBoxProvider = <T,>(props: React.PropsWithChildren<ComboBoxProv
     // duplicated aria-controls/id relationship.
     const listId = useId();
 
+    // Multi-select keeps the selected items *in* the list (rendered checked),
+    // so the list is the single source of truth for what's selected. They are
+    // no longer stripped out — the dropdown, not just the pills, lets the user
+    // see and toggle every selection.
     const allItems = useMemo(() => {
-        if (!props.multiSelect) return props.items ? props.items : []
-
-        return props.items ? props.items.filter(i => !selectedItems.some(si => props.valueField(si) === props.valueField(i))) : []
-
-    }, [JSON.stringify(props.items), selectedItems]);
+        return props.items ? props.items : []
+    }, [JSON.stringify(props.items)]);
 
     const clear = (e: React.MouseEvent<any>) => {
         e.preventDefault();

--- a/moo-ds/src/components/comboBox/__tests__/ComboBoxList.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBoxList.test.tsx
@@ -117,6 +117,53 @@ describe('ComboBoxList', () => {
 
       expect(onAdd).toHaveBeenCalledWith(items[0]);
     });
+
+    it('keeps the dropdown open after selecting in multi-select mode', () => {
+      const { container } = renderWithContainer({ multiSelect: true });
+
+      fireEvent.click(container.querySelector('.combo-box')!);
+      fireEvent.click(screen.getByText('Item 1'));
+
+      // Multi-select is a checklist: the list stays open so more can be picked.
+      expect(container.querySelector('.cb-list')).toBeInTheDocument();
+    });
+
+    it('keeps selected items in the list, marked selected', () => {
+      const { container } = renderWithContainer({ multiSelect: true, selectedItems: [items[0]] });
+
+      fireEvent.click(container.querySelector('.combo-box')!);
+
+      // All three options are still present; the selected one is a checked row.
+      expect(container.querySelectorAll('.cb-list li.cb-option').length).toBe(3);
+      expect(container.querySelector('.cb-list li.cb-option.selected')).toHaveTextContent('Item 1');
+      // The tick must actually draw: fill is none, so without a stroke the
+      // check mark is invisible even when the row is selected.
+      expect(container.querySelector('.cb-list li.cb-option.selected .cb-check path'))
+        .toHaveAttribute('stroke', 'currentColor');
+    });
+
+    it('toggles a selected item off when clicked again in multi-select mode', () => {
+      const onRemove = vi.fn();
+      const onChange = vi.fn();
+      const { container } = renderWithContainer({ multiSelect: true, selectedItems: [items[0]], onRemove, onChange });
+
+      fireEvent.click(container.querySelector('.combo-box')!);
+      // Click the list row (not the pill, which shares the same label text).
+      fireEvent.click(container.querySelector('.cb-list li.cb-option.selected')!);
+
+      expect(onRemove).toHaveBeenCalledWith(items[0]);
+      expect(onChange).toHaveBeenCalledWith([]);
+    });
+
+    it('pins selected items to the top of the list', () => {
+      const { container } = renderWithContainer({ multiSelect: true, selectedItems: [items[2]] });
+
+      fireEvent.click(container.querySelector('.combo-box')!);
+
+      const rows = Array.from(container.querySelectorAll('.cb-list li.cb-option'));
+      // Item 3 is selected, so it sorts above the unselected Item 1 / Item 2.
+      expect(rows[0]).toHaveTextContent('Item 3');
+    });
   });
 
   describe('creatable', () => {

--- a/moo-ds/src/components/comboBox/__tests__/ComboBoxProvider.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBoxProvider.test.tsx
@@ -193,7 +193,7 @@ describe('ComboBoxProvider', () => {
   });
 
   describe('multi-select item filtering', () => {
-    it('filters out selected items from available items in multi-select', () => {
+    it('keeps selected items in the list in multi-select (rendered checked, not stripped)', () => {
       const ItemsCheck = () => {
         const { items } = useComboBox();
         return <span data-testid="available">{items.length}</span>;
@@ -205,8 +205,9 @@ describe('ComboBoxProvider', () => {
         </ComboBoxProvider>
       );
 
-      // Should have 2 available items (3 total - 1 selected)
-      expect(screen.getByTestId('available')).toHaveTextContent('2');
+      // The list is the source of truth for selection: all 3 items remain,
+      // the selected one shown checked rather than removed.
+      expect(screen.getByTestId('available')).toHaveTextContent('3');
     });
   });
 

--- a/moo-ds/src/css/components/_combo-box.css
+++ b/moo-ds/src/css/components/_combo-box.css
@@ -61,13 +61,28 @@
         display: contents;
     }
 
+    /* Expanded: the wrapper becomes its own full-width flex box and wraps the
+       pills over as many rows as needed. Only reachable while the dropdown is
+       closed (the input is hidden then), so it can safely take the whole row. */
+    .cb-pills.expanded {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.75rem;
+        flex: 1 1 100%;
+        min-width: 0;
+        padding: var(--input-padding-v) 0;
+    }
+
     .cb-more {
         display: inline-flex;
         align-items: center;
         padding: 0.35em 0.7em;
+        font-family: inherit;
         font-size: 0.8rem;
         font-weight: 500;
         line-height: 1;
+        border: none;
         border-radius: 50rem;
         background: color-mix(in srgb, var(--body-colour) 12%, transparent);
         color: var(--body-colour-dim);
@@ -114,6 +129,29 @@
             &:hover {
                 background-color: var(--hover);
             }
+        }
+
+        /* Multi-select rows read as checkboxes: a tick gutter on the left that
+           only inks in when the row is selected. Single-select rows have no
+           `.cb-option` class from a checkbox and render as before. */
+        li.cb-option {
+            display: flex;
+            align-items: center;
+            gap: 0.6rem;
+        }
+
+        li.cb-option.selected {
+            background-color: color-mix(in srgb, var(--primary) 10%, transparent);
+        }
+
+        .cb-check {
+            flex: 0 0 auto;
+            color: var(--primary);
+            opacity: 0;
+        }
+
+        li.cb-option.selected .cb-check {
+            opacity: 1;
         }
     }
 


### PR DESCRIPTION
## Summary

When enough tags were selected, the pills collapsed behind a "+N more" chip and — because multi-select stripped selected items from the dropdown — those selections were invisible *and* unremovable. This PR makes the multi-select ComboBox a proper checklist:

- **Selected items stay in the dropdown**, rendered as checked rows (tick + tint, `aria-selected`), pinned to the top. Clicking a row toggles it; the list stays open for further picks.
- **The "+N more" chip is now a button** that expands every pill in place ("show less" collapses). Opening the dropdown re-collapses the pills to one row.
- **Single-select behaviour is unchanged** — picks and closes, no checkbox slot.

Also fixes the check mark drawing nothing (`fill="none"` with no `stroke`), with a regression test.

demoo: new chromeless-until-clicked TagPanel sample on the ComboBox page, and a `.cb-demo` width constraint so pill overflow is easy to exercise.

## Testing

- 1,287 moo-ds tests pass (4 new ComboBoxList tests + tick-stroke assertion; provider test updated to encode the keep-selected-items model).
- Manually exercised in demoo: chip expand/collapse, checklist toggle, pinning, TagPanel readonly toggling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)