### PR TITLE
fix(moo-ds): offer creatable add option when search is set

### DIFF
--- a/moo-ds/src/components/comboBox/ComboBoxInput.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxInput.tsx
@@ -11,7 +11,24 @@ export const ComboBoxInput = ({ placeholder, ...props }: ComboBoxInputProps) => 
     // synchronously on every keystroke with no debounce at all.
     const runSearch = useDebouncedCallback((value: string) => {
         if (!search) return;
-        setItems(search(value));
+        const results = search(value);
+        setItems(results);
+
+        // Mirror the non-search branch's creatable flow: offer "Add '…'" when
+        // the typed text matches none of the results. Empty input never
+        // offers an add option.
+        if (creatable && value !== "" && !results.some((i) => labelField(i).toString().toLowerCase() === value.toLowerCase())) {
+
+            const addItem = newItem ? newItem : {};
+
+            addItem.label = createLabel(value);
+
+            setNewItem(addItem);
+        }
+        else if (creatable) {
+            setNewItem(null);
+        }
+
         setShow(true);
     }, 300);
 

--- a/moo-ds/src/components/comboBox/__tests__/ComboBoxInput.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBoxInput.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ComboBoxInput } from '../ComboBoxInput';
 import { ComboBoxProvider } from '../ComboBoxProvider';
+import { ComboBoxList } from '../ComboBoxList';
 
 interface Item {
   id: number;
@@ -184,6 +185,78 @@ describe('ComboBoxInput', () => {
 
       // Input visibility is controlled by showInput state
       expect(container.querySelector('input')).toBeInTheDocument();
+    });
+  });
+
+  describe('creatable with search', () => {
+    const renderCreatableSearch = (search: (input: string) => Item[], onCreate = vi.fn()) => {
+      render(
+        <ComboBoxProvider
+          {...defaultProps}
+          search={search}
+          creatable
+          createLabel={(input: string) => `Add "${input}"`}
+          onCreate={onCreate}
+        >
+          <ComboBoxInput placeholder="Search..." readonly={false} />
+          <ComboBoxList />
+        </ComboBoxProvider>
+      );
+      return onCreate;
+    };
+
+    it('offers the add option when no search result matches the typed text', () => {
+      vi.useFakeTimers();
+      try {
+        const onCreate = renderCreatableSearch(vi.fn().mockReturnValue([items[0]]));
+
+        fireEvent.change(screen.getByRole('combobox'), { target: { value: 'Pear' } });
+        act(() => {
+          vi.advanceTimersByTime(300);
+        });
+
+        const addOption = screen.getByText('Add "Pear"');
+        expect(addOption).toBeInTheDocument();
+
+        fireEvent.click(addOption);
+        expect(onCreate).toHaveBeenCalledWith('Pear');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not offer the add option when a search result matches case-insensitively', () => {
+      vi.useFakeTimers();
+      try {
+        renderCreatableSearch(vi.fn().mockReturnValue([items[0]])); // Apple
+
+        fireEvent.change(screen.getByRole('combobox'), { target: { value: 'apple' } });
+        act(() => {
+          vi.advanceTimersByTime(300);
+        });
+
+        expect(screen.queryByText('Add "apple"')).not.toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not offer the add option for empty input', () => {
+      vi.useFakeTimers();
+      try {
+        renderCreatableSearch(vi.fn().mockReturnValue([]));
+
+        const input = screen.getByRole('combobox');
+        fireEvent.change(input, { target: { value: 'x' } });
+        fireEvent.change(input, { target: { value: '' } });
+        act(() => {
+          vi.advanceTimersByTime(300);
+        });
+
+        expect(screen.queryByText(/^Add "/)).not.toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });


### PR DESCRIPTION
The creatable newItem flow lived only in the non-search branch of ComboBoxInput.onChange, so a ComboBox with a search callback never offered to add free text. Run the same check against the search results inside the debounced search path, and clear a stale add option when the text becomes empty or matches a result.

Needed by Wrangler's unified filter experience (author picker: remote typeahead + free-entry bot logins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)