### PR TITLE
fix(moo-ds): clear stale creatable add option on create and empty input

### DIFF
--- a/moo-ds/src/components/comboBox/ComboBoxInput.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxInput.tsx
@@ -43,13 +43,16 @@ export const ComboBoxInput = ({ placeholder, ...props }: ComboBoxInputProps) => 
         else {
             const tempItems = allItems.filter((i) => labelField(i).toString().toLowerCase().indexOf(value.toLowerCase()) > -1);
 
-            if (creatable && !allItems.some((i) => labelField(i).toString().toLowerCase() === value.toLowerCase())) {
+            if (creatable && value !== "" && !allItems.some((i) => labelField(i).toString().toLowerCase() === value.toLowerCase())) {
 
                 const addItem = newItem ? newItem : {};
 
                 addItem.label = createLabel(value);
 
                 setNewItem(addItem);
+            }
+            else if (creatable) {
+                setNewItem(null);
             }
 
             setItems(tempItems);

--- a/moo-ds/src/components/comboBox/ComboBoxList.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxList.tsx
@@ -3,7 +3,7 @@ import { useComboBox } from "./ComboBoxProvider";
 
 export const ComboBoxList = () => {
 
-    const { creatable, items, multiSelect, onAdd, onRemove, onChange, onCreate, show, setShow, newItem, selectedItems, setSelectedItems, setText, text, valueField, listId } = useComboBox();
+    const { creatable, items, multiSelect, onAdd, onRemove, onChange, onCreate, show, setShow, newItem, setNewItem, selectedItems, setSelectedItems, setText, text, valueField, listId } = useComboBox();
 
     if (!show) return null;
 
@@ -39,6 +39,7 @@ export const ComboBoxList = () => {
         onCreate?.(text);
         setText("");
         setShow(false);
+        setNewItem(null);
     }
 
     // Multi-select pins the checked items to the top so "see everything I've

--- a/moo-ds/src/components/comboBox/__tests__/ComboBoxList.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBoxList.test.tsx
@@ -202,5 +202,46 @@ describe('ComboBoxList', () => {
 
       expect(onCreate).toHaveBeenCalledWith('New Item');
     });
+
+    it('creating an item clears the add option', () => {
+      const onCreate = vi.fn();
+      const { container } = renderWithContainer({
+        creatable: true,
+        onCreate,
+        createLabel: (text: string) => `Add "${text}"`,
+      });
+
+      fireEvent.click(container.querySelector('.combo-box')!);
+
+      const input = screen.getByRole('combobox');
+      fireEvent.change(input, { target: { value: 'x' } });
+      expect(screen.getByText('Add "x"')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText('Add "x"'));
+      expect(onCreate).toHaveBeenCalledWith('x');
+
+      // Re-open the dropdown after creating: the stale add row for the
+      // now-cleared text must not still be there.
+      fireEvent.click(container.querySelector('.combo-box')!);
+      expect(screen.queryByText('Add "x"')).not.toBeInTheDocument();
+    });
+
+    it('empty input clears the add option (non-search)', () => {
+      const onCreate = vi.fn();
+      const { container } = renderWithContainer({
+        creatable: true,
+        onCreate,
+        createLabel: (text: string) => `Add "${text}"`,
+      });
+
+      fireEvent.click(container.querySelector('.combo-box')!);
+
+      const input = screen.getByRole('combobox');
+      fireEvent.change(input, { target: { value: 'x' } });
+      expect(screen.getByText('Add "x"')).toBeInTheDocument();
+
+      fireEvent.change(input, { target: { value: '' } });
+      expect(screen.queryByText(/^Add "/)).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Found by Wrangler's unified-filter-experience final review: after creating an item the add row persisted (dead click firing onCreate("")), and the non-search branch offered Add '' for empty input.