### PR TITLE
feat(moo-app): recover from 401 responses with a single forced token refresh

### DIFF
--- a/moo-app/src/MooApp.tsx
+++ b/moo-app/src/MooApp.tsx
@@ -4,7 +4,7 @@ import { PersistQueryClientProvider, type PersistQueryClientOptions } from "@tan
 import { type AnyRouter, RouterProvider } from "@tanstack/react-router";
 
 import { Link, NavLink } from "./components";
-import { AppProvider, MsalAuthProvider } from "./providers";
+import { AppProvider, MsalAuthProvider, isAuthCancellation } from "./providers";
 import { LinkProvider, MessageProvider, ThemeProvider } from "@andrewmclachlan/moo-ds";
 
 import getMsalInstance, { AUTH_RECOVERED_EVENT, type MsalOptions } from "./login/msal";
@@ -36,7 +36,13 @@ export const MooApp: React.FC<PropsWithChildren<MooAppProps>> = ({ router, clien
     defaultOptions: {
       queries: {
         refetchOnWindowFocus: false,
-        retry: false,
+        // Requests cancelled by the auth interceptor (token being refreshed /
+        // interactive redirect imminent) are retried a bounded number of times
+        // so queries stay pending across the auth window instead of flashing
+        // errors; anything else fails fast. If no redirect materialises the
+        // retries exhaust in ~2.5s and the error surfaces normally.
+        retry: (failureCount, error) => isAuthCancellation(error) && failureCount < 5,
+        retryDelay: 500,
         networkMode: "offlineFirst",
       },
       mutations: {

--- a/moo-app/src/providers/MsalAuthProvider.tsx
+++ b/moo-app/src/providers/MsalAuthProvider.tsx
@@ -30,11 +30,37 @@ const getRedirectState = (client: IPublicClientApplication): RedirectState => {
     return state;
 };
 
+/** Marker carried by cancellations raised by the auth interceptors. */
+const authCancellationMarker = Symbol.for("mooapp.authCancellation");
+
+type MarkedCanceledError = InstanceType<typeof axios.CanceledError> & { [authCancellationMarker]?: boolean };
+
+const authCanceledError = (message: string): MarkedCanceledError =>
+    Object.assign(new axios.CanceledError(message) as MarkedCanceledError, { [authCancellationMarker]: true });
+
 /**
- * Attaches an MSAL access-token request interceptor to the supplied axios
- * instance. Tokens are acquired silently; on a recoverable MSAL auth error the
- * request falls back to an interactive redirect. Renders its children unchanged
- * — it exposes no context, it only wires up the client.
+ * True when the error is a request cancellation raised by the MSAL auth
+ * interceptors (silent acquisition failed / an interactive redirect is being
+ * initiated). Lets query-layer retry policy keep these requests pending across
+ * an auth window instead of surfacing them as hard errors.
+ */
+export const isAuthCancellation = (error: unknown): boolean =>
+    axios.isCancel(error) && (error as MarkedCanceledError)[authCancellationMarker] === true;
+
+/** Axios config flag capping 401 recovery at a single retry per request. */
+type RetriableConfig = InternalAxiosRequestConfig & { mooappRetriedAfter401?: boolean };
+
+// One force-refresh in flight per MSAL instance: a page of widgets failing
+// together must not stampede the token endpoint.
+const forceRefreshByInstance = new WeakMap<IPublicClientApplication, Promise<AuthenticationResult>>();
+
+/**
+ * Attaches MSAL access-token interceptors to the supplied axios instance:
+ * a request interceptor that acquires tokens silently (falling back to an
+ * interactive redirect on recoverable auth errors), and a response interceptor
+ * that recovers from a 401 by force-refreshing the token and retrying the
+ * request once. Renders its children unchanged — it exposes no context, it
+ * only wires up the client.
  */
 export const MsalAuthProvider: React.FC<React.PropsWithChildren<MsalAuthProviderProps>> = ({ client, scopes = [], children }) => {
 
@@ -82,8 +108,13 @@ export const MsalAuthProvider: React.FC<React.PropsWithChildren<MsalAuthProvider
         const interceptorId = client.interceptors.request.use(
             (request) => acquireTokenForRequest(request, msalRef, scopesRef)
         );
+        const responseInterceptorId = client.interceptors.response.use(
+            undefined,
+            (error) => retryAfterUnauthorized(error, client, msalRef, scopesRef)
+        );
         return () => {
             client.interceptors.request.eject(interceptorId);
+            client.interceptors.response.eject(responseInterceptorId);
         };
     }, [client]);
 
@@ -94,6 +125,69 @@ export const MsalAuthProvider: React.FC<React.PropsWithChildren<MsalAuthProvider
     );
 }
 
+const buildSilentRequest = (msal: IMsalContext, scopes: string[]): SilentRequest => {
+    const account = msal.instance.getActiveAccount() ?? msal.instance.getAllAccounts()[0];
+
+    // Point silent renewals at a blank page (if configured) so the hidden iframe
+    // doesn't re-boot the SPA and trigger block_iframe_reload. Interactive
+    // redirects intentionally keep the default redirectUri so the user is
+    // returned to the page that initiated login.
+    const silentRedirectUri = getSilentRedirectUri();
+
+    return {
+        scopes: scopes ?? [],
+        ...(account ? { account } : {}),
+        ...(silentRedirectUri ? { redirectUri: silentRedirectUri } : {})
+    };
+};
+
+/**
+ * Shared failure path for silent token acquisition. Non-recoverable errors
+ * (network failures, misconfiguration, interaction already in progress) cancel
+ * the request outright; recoverable MSAL auth errors trigger a single guarded
+ * interactive redirect. Always throws.
+ */
+const handleSilentFailure = async (
+    error: unknown,
+    msal: IMsalContext,
+    scopes: string[],
+    silentRequest: SilentRequest,
+): Promise<never> => {
+    const errorCode = (error as AuthError)?.errorCode;
+
+    // Don't redirect for non-recoverable errors (network failures,
+    // misconfiguration, or an interaction already in progress).
+    const isNonRecoverable =
+        errorCode === "network_error" ||
+        errorCode === "interaction_in_progress" ||
+        !(error instanceof AuthError);
+
+    if (isNonRecoverable) {
+        console.warn("Error getting token silently:", error, "errorCode:", errorCode);
+        throw authCanceledError("Request canceled: unable to acquire authentication token.");
+    }
+
+    // For any MSAL auth error (expired tokens, consent required, iframe
+    // timeouts, etc.), fall back to interactive redirect.
+    const redirectState = getRedirectState(msal.instance);
+    if (!redirectState.redirectInFlight && msal.inProgress === InteractionStatus.None) {
+        redirectState.redirectInFlight = true;
+        const interactiveScopes = Array.from(new Set([...(loginRequest.scopes ?? []), ...scopes]));
+        try {
+            await msal.instance.acquireTokenRedirect({
+                ...loginRequest,
+                scopes: interactiveScopes,
+                ...(silentRequest.account ? { account: silentRequest.account } : {})
+            });
+        } catch (redirectError) {
+            redirectState.redirectInFlight = false;
+            throw redirectError;
+        }
+    }
+
+    throw authCanceledError("Request canceled: interactive authentication redirect required.");
+};
+
 const acquireTokenForRequest = async (
     request: InternalAxiosRequestConfig,
     msalRef: React.RefObject<IMsalContext>,
@@ -103,57 +197,13 @@ const acquireTokenForRequest = async (
     const scopes = scopesRef.current;
 
     let token: AuthenticationResult;
-    const account = msal.instance.getActiveAccount() ?? msal.instance.getAllAccounts()[0];
-    const redirectState = getRedirectState(msal.instance);
-
-    // Point silent renewals at a blank page (if configured) so the hidden iframe
-    // doesn't re-boot the SPA and trigger block_iframe_reload. Interactive
-    // redirects below intentionally keep the default redirectUri so the user is
-    // returned to the page that initiated login.
-    const silentRedirectUri = getSilentRedirectUri();
-
-    const tokenRequest: SilentRequest = {
-        scopes: scopes ?? [],
-        ...(account ? { account } : {}),
-        ...(silentRedirectUri ? { redirectUri: silentRedirectUri } : {})
-    };
+    const tokenRequest = buildSilentRequest(msal, scopes);
 
     try {
         token = await msal.instance.acquireTokenSilent(tokenRequest);
     }
     catch (error) {
-        const errorCode = (error as AuthError)?.errorCode;
-
-        // Don't redirect for non-recoverable errors (network failures,
-        // misconfiguration, or an interaction already in progress).
-        const isNonRecoverable =
-            errorCode === "network_error" ||
-            errorCode === "interaction_in_progress" ||
-            !(error instanceof AuthError);
-
-        if (isNonRecoverable) {
-            console.warn("Error getting token silently:", error, "errorCode:", errorCode);
-            throw new axios.CanceledError("Request canceled: unable to acquire authentication token.");
-        }
-
-        // For any MSAL auth error (expired tokens, consent required, iframe
-        // timeouts, etc.), fall back to interactive redirect.
-        if (!redirectState.redirectInFlight && msal.inProgress === InteractionStatus.None) {
-            redirectState.redirectInFlight = true;
-            const interactiveScopes = Array.from(new Set([...(loginRequest.scopes ?? []), ...scopes]));
-            try {
-                await msal.instance.acquireTokenRedirect({
-                    ...loginRequest,
-                    scopes: interactiveScopes,
-                    ...(account ? { account } : {})
-                });
-            } catch (redirectError) {
-                redirectState.redirectInFlight = false;
-                throw redirectError;
-            }
-        }
-
-        throw new axios.CanceledError("Request canceled: interactive authentication redirect required.");
+        return handleSilentFailure(error, msal, scopes, tokenRequest);
     }
 
     if (token.accessToken) {
@@ -164,14 +214,81 @@ const acquireTokenForRequest = async (
 };
 
 /**
- * Attaches the MSAL access-token interceptor to an arbitrary axios instance
- * imperatively (used internally for the MS Graph client). Returns the
- * interceptor id so it can be ejected.
+ * Response-side recovery: MSAL judges token validity by local expiry alone, so
+ * a token the server rejects (signing-key rollover, Conditional Access /
+ * sign-in frequency, clock skew) would otherwise fail every request until it
+ * naturally expires. On a 401, force-refresh the token and retry the request
+ * exactly once.
+ *
+ * Loop safety: the retry is capped by a per-request config flag (a retried
+ * request that 401s again rejects with the original error), the force refresh
+ * is single-flight per MSAL instance, and a failed refresh falls into the same
+ * guarded redirect path as request-side failures — it never triggers another
+ * retry.
+ */
+const retryAfterUnauthorized = async (
+    error: unknown,
+    client: AxiosInstance,
+    msalRef: React.RefObject<IMsalContext>,
+    scopesRef: React.RefObject<string[]>,
+): Promise<unknown> => {
+    if (!axios.isAxiosError(error) || error.response?.status !== 401) {
+        throw error;
+    }
+
+    const config = error.config as RetriableConfig | undefined;
+    if (!config || config.mooappRetriedAfter401) {
+        throw error;
+    }
+    config.mooappRetriedAfter401 = true;
+
+    const msal = msalRef.current;
+    const scopes = scopesRef.current;
+    const tokenRequest = buildSilentRequest(msal, scopes);
+
+    let inflight = forceRefreshByInstance.get(msal.instance);
+    if (!inflight) {
+        inflight = msal.instance
+            .acquireTokenSilent({ ...tokenRequest, forceRefresh: true })
+            .finally(() => { forceRefreshByInstance.delete(msal.instance); });
+        forceRefreshByInstance.set(msal.instance, inflight);
+    }
+
+    let token: AuthenticationResult;
+    try {
+        token = await inflight;
+    }
+    catch (refreshError) {
+        return handleSilentFailure(refreshError, msal, scopes, tokenRequest);
+    }
+
+    if (!token.accessToken) {
+        throw error;
+    }
+
+    // Success also fires ACQUIRE_TOKEN_SUCCESS, which dispatches
+    // AUTH_RECOVERED_EVENT — any queries that already errored refetch.
+    config.headers.setAuthorization(`Bearer ${token.accessToken}`);
+    return client.request(config);
+};
+
+/**
+ * Attaches the MSAL access-token interceptors to an arbitrary axios instance
+ * imperatively (used internally for the MS Graph client). Returns a function
+ * that ejects both interceptors.
  */
 export const addMsalInterceptor = (httpClient: AxiosInstance, msal: IMsalContext, scopes: string[]) => {
     const msalRef = { current: msal } as React.RefObject<IMsalContext>;
     const scopesRef = { current: scopes } as React.RefObject<string[]>;
-    return httpClient.interceptors.request.use(
+    const responseInterceptorId = httpClient.interceptors.response.use(
+        undefined,
+        (error) => retryAfterUnauthorized(error, httpClient, msalRef, scopesRef)
+    );
+    const requestInterceptorId = httpClient.interceptors.request.use(
         (request) => acquireTokenForRequest(request, msalRef, scopesRef)
     );
+    return () => {
+        httpClient.interceptors.request.eject(requestInterceptorId);
+        httpClient.interceptors.response.eject(responseInterceptorId);
+    };
 }

--- a/moo-app/src/providers/__tests__/MsalAuthProvider.test.tsx
+++ b/moo-app/src/providers/__tests__/MsalAuthProvider.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import axios from 'axios';
 import { AuthError } from '@azure/msal-browser';
-import { MsalAuthProvider, addMsalInterceptor } from '../MsalAuthProvider';
+import { MsalAuthProvider, addMsalInterceptor, isAuthCancellation } from '../MsalAuthProvider';
 
 // Mock MSAL react context for the component test
 const mockAcquireTokenSilent = vi.fn();
@@ -233,5 +233,174 @@ describe('addMsalInterceptor', () => {
       expect(consoleSpy).toHaveBeenCalled();
       consoleSpy.mockRestore();
     });
+  });
+
+  describe('auth cancellation marker', () => {
+    it('marks interceptor cancellations so callers can identify them', async () => {
+      const error = new AuthError('interaction_required', 'interaction_required');
+      const msal = createMockMsal({
+        acquireTokenSilent: vi.fn().mockRejectedValue(error),
+        acquireTokenRedirect: vi.fn().mockResolvedValue(null),
+      });
+      const client = createClientWithInterceptor(msal);
+
+      const rejection = await client.get('/api/data').then(
+        () => { throw new Error('expected rejection'); },
+        (e) => e,
+      );
+
+      expect(isAuthCancellation(rejection)).toBe(true);
+    });
+
+    it('does not identify ordinary errors as auth cancellations', () => {
+      expect(isAuthCancellation(new Error('boom'))).toBe(false);
+      expect(isAuthCancellation(new axios.CanceledError('user canceled'))).toBe(false);
+      expect(isAuthCancellation(undefined)).toBe(false);
+    });
+  });
+});
+
+describe('401 response recovery', () => {
+  const createMockMsal = (overrides: Record<string, any> = {}) => ({
+    instance: {
+      acquireTokenSilent: vi.fn(),
+      acquireTokenRedirect: vi.fn(),
+      getActiveAccount: vi.fn().mockReturnValue({ homeAccountId: 'acct' }),
+      getAllAccounts: vi.fn().mockReturnValue([{ homeAccountId: 'acct' }]),
+      ...overrides,
+    },
+    accounts: [],
+    inProgress: 'none',
+  } as any);
+
+  /**
+   * Adapter that answers each request with the next status in the queue
+   * (repeating the last one), so a 401-then-200 sequence can be scripted.
+   */
+  const createClientWithStatusQueue = (msal: any, statuses: number[], scopes: string[] = ['api://test']) => {
+    const client = axios.create();
+    const calls: { auth: string | undefined }[] = [];
+    client.defaults.adapter = async (config) => {
+      const status = statuses.length > 1 ? statuses.shift()! : statuses[0];
+      calls.push({ auth: config.headers.Authorization as string | undefined });
+      const response = { data: {}, status, statusText: String(status), headers: {}, config } as any;
+      if (status >= 400) {
+        throw new axios.AxiosError(`Request failed with status code ${status}`, String(status), config as any, {}, response);
+      }
+      return response;
+    };
+    addMsalInterceptor(client, msal, scopes);
+    return { client, calls };
+  };
+
+  beforeEach(() => {
+    mockGetSilentRedirectUri.mockReturnValue(undefined);
+  });
+
+  it('force-refreshes the token and retries once on 401', async () => {
+    const acquireTokenSilent = vi.fn()
+      .mockResolvedValueOnce({ accessToken: 'stale-token' })   // request interceptor (initial)
+      .mockResolvedValueOnce({ accessToken: 'fresh-token' })   // force refresh
+      .mockResolvedValue({ accessToken: 'fresh-token' });      // request interceptor (retry)
+    const msal = createMockMsal({ acquireTokenSilent });
+    const { client, calls } = createClientWithStatusQueue(msal, [401, 200]);
+
+    const response = await client.get('/api/data');
+
+    expect(response.status).toBe(200);
+    expect(acquireTokenSilent).toHaveBeenCalledWith(expect.objectContaining({ forceRefresh: true }));
+    expect(calls).toHaveLength(2);
+    expect(calls[1].auth).toBe('Bearer fresh-token');
+  });
+
+  it('does not retry a second time when the retried request also 401s', async () => {
+    const acquireTokenSilent = vi.fn().mockResolvedValue({ accessToken: 'token' });
+    const msal = createMockMsal({ acquireTokenSilent });
+    const { client, calls } = createClientWithStatusQueue(msal, [401]);
+
+    const rejection = await client.get('/api/data').then(
+      () => { throw new Error('expected rejection'); },
+      (e) => e,
+    );
+
+    expect(rejection.response?.status).toBe(401);
+    expect(calls).toHaveLength(2); // original + exactly one retry
+    const forceRefreshCalls = acquireTokenSilent.mock.calls.filter(([req]) => req?.forceRefresh);
+    expect(forceRefreshCalls).toHaveLength(1);
+  });
+
+  it('shares a single force-refresh across concurrent 401s', async () => {
+    let resolveRefresh: (v: any) => void;
+    const refreshPromise = new Promise((resolve) => { resolveRefresh = resolve; });
+    const acquireTokenSilent = vi.fn().mockImplementation((req) =>
+      req?.forceRefresh ? refreshPromise : Promise.resolve({ accessToken: 'stale-token' }));
+    const msal = createMockMsal({ acquireTokenSilent });
+    const { client } = createClientWithStatusQueue(msal, [401, 401, 200]);
+
+    // Settle rejections inline so neither can surface as unhandled while the
+    // refresh is deliberately held open.
+    const first = client.get('/api/one').catch((e) => e);
+    const second = client.get('/api/two').catch((e) => e);
+    // Let both requests 401 and enter the refresh path before resolving it.
+    await new Promise((r) => setTimeout(r, 10));
+    resolveRefresh!({ accessToken: 'fresh-token' });
+    await Promise.all([first, second]);
+
+    const forceRefreshCalls = acquireTokenSilent.mock.calls.filter(([req]) => req?.forceRefresh);
+    expect(forceRefreshCalls).toHaveLength(1);
+  });
+
+  it('falls back to the guarded redirect when the force refresh needs interaction', async () => {
+    const acquireTokenRedirect = vi.fn().mockResolvedValue(null);
+    const acquireTokenSilent = vi.fn().mockImplementation((req) =>
+      req?.forceRefresh
+        ? Promise.reject(new AuthError('interaction_required', 'interaction_required'))
+        : Promise.resolve({ accessToken: 'stale-token' }));
+    const msal = createMockMsal({ acquireTokenSilent, acquireTokenRedirect });
+    const { client } = createClientWithStatusQueue(msal, [401]);
+
+    const rejection = await client.get('/api/data').then(
+      () => { throw new Error('expected rejection'); },
+      (e) => e,
+    );
+
+    expect(acquireTokenRedirect).toHaveBeenCalledTimes(1);
+    expect(isAuthCancellation(rejection)).toBe(true);
+  });
+
+  it('does not redirect when the force refresh fails with a network error', async () => {
+    const acquireTokenRedirect = vi.fn();
+    const acquireTokenSilent = vi.fn().mockImplementation((req) =>
+      req?.forceRefresh
+        ? Promise.reject(new AuthError('network_error', 'network_error'))
+        : Promise.resolve({ accessToken: 'stale-token' }));
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const msal = createMockMsal({ acquireTokenSilent, acquireTokenRedirect });
+    const { client } = createClientWithStatusQueue(msal, [401]);
+
+    const rejection = await client.get('/api/data').then(
+      () => { throw new Error('expected rejection'); },
+      (e) => e,
+    );
+
+    expect(acquireTokenRedirect).not.toHaveBeenCalled();
+    expect(isAuthCancellation(rejection)).toBe(true);
+    consoleSpy.mockRestore();
+  });
+
+  it('passes non-401 response errors through untouched', async () => {
+    const acquireTokenSilent = vi.fn().mockResolvedValue({ accessToken: 'token' });
+    const msal = createMockMsal({ acquireTokenSilent });
+    const { client, calls } = createClientWithStatusQueue(msal, [500]);
+
+    const rejection = await client.get('/api/data').then(
+      () => { throw new Error('expected rejection'); },
+      (e) => e,
+    );
+
+    expect(rejection.response?.status).toBe(500);
+    expect(calls).toHaveLength(1); // no retry
+    const forceRefreshCalls = acquireTokenSilent.mock.calls.filter(([req]) => req?.forceRefresh);
+    expect(forceRefreshCalls).toHaveLength(0);
   });
 });

--- a/moo-app/src/providers/__tests__/MsalAuthProvider.test.tsx
+++ b/moo-app/src/providers/__tests__/MsalAuthProvider.test.tsx
@@ -282,7 +282,7 @@ describe('401 response recovery', () => {
     const calls: { auth: string | undefined }[] = [];
     client.defaults.adapter = async (config) => {
       const status = statuses.length > 1 ? statuses.shift()! : statuses[0];
-      calls.push({ auth: config.headers.Authorization as string | undefined });
+      calls.push({ auth: config.headers.getAuthorization() as string | undefined });
       const response = { data: {}, status, statusText: String(status), headers: {}, config } as any;
       if (status >= 400) {
         throw new axios.AxiosError(`Request failed with status code ${status}`, String(status), config as any, {}, response);

--- a/moo-app/src/providers/index.ts
+++ b/moo-app/src/providers/index.ts
@@ -2,5 +2,5 @@ export * from "./AppProvider";
 // addMsalInterceptor is intentionally NOT re-exported: it is internal glue
 // (used by the Graph client in services/msgraph.ts) and not part of the public
 // API. Consumers use MsalAuthProvider.
-export { MsalAuthProvider, type MsalAuthProviderProps } from "./MsalAuthProvider";
+export { MsalAuthProvider, isAuthCancellation, type MsalAuthProviderProps } from "./MsalAuthProvider";
 export * from "./LayoutProvider";

--- a/moo-app/src/services/__tests__/msgraph.test.tsx
+++ b/moo-app/src/services/__tests__/msgraph.test.tsx
@@ -23,7 +23,7 @@ vi.mock('axios', () => ({
 }));
 
 vi.mock('../../providers/MsalAuthProvider', () => ({
-  addMsalInterceptor: () => 1,
+  addMsalInterceptor: () => () => {},
 }));
 
 import { usePhoto } from '../msgraph';

--- a/moo-app/src/services/msgraph.ts
+++ b/moo-app/src/services/msgraph.ts
@@ -11,9 +11,9 @@ export const usePhoto = () => {
     const httpClient = useMemo(() => axios.create({ baseURL: "https://graph.microsoft.com/v1.0", headers: { "Accept": "application/json" } }), []);
 
     useEffect(() => {
-        const interceptorId = addMsalInterceptor(httpClient, msal, ["User.Read"]);
+        const ejectInterceptors = addMsalInterceptor(httpClient, msal, ["User.Read"]);
         return () => {
-            httpClient.interceptors.request.eject(interceptorId);
+            ejectInterceptors();
         };
     }, [httpClient, msal]);
 


### PR DESCRIPTION
## Problem

MSAL judges token validity by local expiry alone — the request interceptor has no response-side handling. When the API rejects a token MSAL still considers valid (signing-key rollover, Conditional Access sign-in frequency, clock skew after sleep), every request 401s, and with `retry: false` the app sits in a permanent widget-error state that F5 cannot clear (MooBank dashboard symptom).

## Changes

**401 response interceptor** — on 401, `acquireTokenSilent({ forceRefresh: true })` and retry the request exactly once.

Loop safety (deliberate, since a 401 retry loop is a UX killer):
- Per-request `mooappRetriedAfter401` config flag — a retried request that 401s again rejects with the original error; no second attempt
- Single-flight force refresh per MSAL instance — a page of concurrently-failing widgets shares one token call
- A failed refresh falls into the existing guarded redirect path (`redirectInFlight` + `inProgress` checks); it never triggers another retry
- Non-401 errors pass through untouched

**Pending-not-error across auth windows** — interceptor cancellations are now marked and `isAuthCancellation()` is exported; the QueryClient default `retry` keeps auth-cancelled queries pending (5 × 500 ms) so widgets show spinners through an auth redirect instead of flashing "Unable to load". If no redirect materialises the retries exhaust in ~2.5 s and the error surfaces normally.

**`addMsalInterceptor`** now returns an eject function covering both interceptors (response interceptor would previously have leaked on unmount). Internal API; the one consumer (msgraph) updated.

A successful forced refresh fires `ACQUIRE_TOKEN_SUCCESS` → `AUTH_RECOVERED_EVENT`, so one request's recovery refetches every other errored query — the whole dashboard heals from a single 401 recovery.

## Testing

- 8 new tests: refresh-and-retry-once, no-second-retry, single-flight under concurrency, guarded redirect on refresh failure, no redirect on network error, non-401 passthrough, cancellation marker semantics
- Full moo-app suite: 245/245 pass; build clean; no new lint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)