### PR TITLE
feat(moo-ds): extend breakpoint scale for large displays

### DIFF
--- a/moo-ds/src/components/Col.tsx
+++ b/moo-ds/src/components/Col.tsx
@@ -9,6 +9,12 @@ export interface ColProps extends React.HTMLAttributes<HTMLElement> {
     lg?: number | boolean;
     xl?: number | boolean;
     xxl?: number | boolean;
+    /** ≥1880px — 1920 (Full HD) class displays. */
+    fhd?: number | boolean;
+    /** ≥2520px — 2560 (Quad HD) class displays. */
+    qhd?: number | boolean;
+    /** ≥3200px — ultrawide/4K class displays. */
+    uhd?: number | boolean;
 }
 
 function colClass(breakpoint: string, value: number | boolean | undefined): string | undefined {
@@ -18,7 +24,7 @@ function colClass(breakpoint: string, value: number | boolean | undefined): stri
 }
 
 export const Col = React.forwardRef<HTMLElement, React.PropsWithChildren<ColProps>>(
-    ({ as: Tag = "div", xs, sm, md, lg, xl, xxl, className, children, ...rest }, ref) => {
+    ({ as: Tag = "div", xs, sm, md, lg, xl, xxl, fhd, qhd, uhd, className, children, ...rest }, ref) => {
         const classes = classNames(
             colClass("", xs),
             colClass("sm", sm),
@@ -26,8 +32,11 @@ export const Col = React.forwardRef<HTMLElement, React.PropsWithChildren<ColProp
             colClass("lg", lg),
             colClass("xl", xl),
             colClass("xxl", xxl),
+            colClass("fhd", fhd),
+            colClass("qhd", qhd),
+            colClass("uhd", uhd),
             // Default to col if no breakpoint specified
-            !xs && !sm && !md && !lg && !xl && !xxl && "col",
+            !xs && !sm && !md && !lg && !xl && !xxl && !fhd && !qhd && !uhd && "col",
             className,
         );
 

--- a/moo-ds/src/components/__tests__/Col.test.tsx
+++ b/moo-ds/src/components/__tests__/Col.test.tsx
@@ -39,6 +39,17 @@ describe('Col', () => {
     expect(col).toHaveClass('col-12', 'col-md-6', 'col-lg-4');
   });
 
+  it('applies extended breakpoint classes (fhd/qhd/uhd)', () => {
+    render(<Col fhd={3} qhd={2} uhd={1} data-testid="col">Content</Col>);
+    const col = screen.getByTestId('col');
+    expect(col).toHaveClass('col-fhd-3', 'col-qhd-2', 'col-uhd-1');
+  });
+
+  it('does not add the default col class when only an extended breakpoint is set', () => {
+    render(<Col fhd={3} data-testid="col">Content</Col>);
+    expect(screen.getByTestId('col')).not.toHaveClass('col');
+  });
+
   it('supports boolean breakpoint for auto-width', () => {
     render(<Col sm={true} data-testid="col">Content</Col>);
     expect(screen.getByTestId('col')).toHaveClass('col-sm');

--- a/moo-ds/src/css/_moo-grid.css
+++ b/moo-ds/src/css/_moo-grid.css
@@ -31,8 +31,20 @@
     .container { max-width: 1140px; }
 }
 
-@media (min-width: 1400px) {
-    .container { max-width: 1320px; }
+@media (min-width: 1500px) {
+    .container { max-width: 1420px; }
+}
+
+@media (min-width: 1880px) {
+    .container { max-width: 1800px; }
+}
+
+@media (min-width: 2520px) {
+    .container { max-width: 2440px; }
+}
+
+@media (min-width: 3200px) {
+    .container { max-width: 3120px; }
 }
 
 .row {
@@ -137,7 +149,7 @@
     .col-xl-12 { flex: 0 0 auto; width: 100%; }
 }
 
-@media (min-width: 1400px) {
+@media (min-width: 1500px) {
     .col-xxl { flex: 1 0 0%; }
     .col-xxl-auto { flex: 0 0 auto; width: auto; }
     .col-xxl-1 { flex: 0 0 auto; width: 8.33333333%; }
@@ -152,4 +164,58 @@
     .col-xxl-10 { flex: 0 0 auto; width: 83.33333333%; }
     .col-xxl-11 { flex: 0 0 auto; width: 91.66666667%; }
     .col-xxl-12 { flex: 0 0 auto; width: 100%; }
+}
+
+/* Extended breakpoints beyond the Bootstrap-derived scale, named for the
+   display classes they target (allowing for scrollbars/borders):
+   fhd 1880 (1920 Full HD), qhd 2520 (2560 Quad HD), uhd 3200 (3440+/4K). */
+@media (min-width: 1880px) {
+    .col-fhd { flex: 1 0 0%; }
+    .col-fhd-auto { flex: 0 0 auto; width: auto; }
+    .col-fhd-1 { flex: 0 0 auto; width: 8.33333333%; }
+    .col-fhd-2 { flex: 0 0 auto; width: 16.66666667%; }
+    .col-fhd-3 { flex: 0 0 auto; width: 25%; }
+    .col-fhd-4 { flex: 0 0 auto; width: 33.33333333%; }
+    .col-fhd-5 { flex: 0 0 auto; width: 41.66666667%; }
+    .col-fhd-6 { flex: 0 0 auto; width: 50%; }
+    .col-fhd-7 { flex: 0 0 auto; width: 58.33333333%; }
+    .col-fhd-8 { flex: 0 0 auto; width: 66.66666667%; }
+    .col-fhd-9 { flex: 0 0 auto; width: 75%; }
+    .col-fhd-10 { flex: 0 0 auto; width: 83.33333333%; }
+    .col-fhd-11 { flex: 0 0 auto; width: 91.66666667%; }
+    .col-fhd-12 { flex: 0 0 auto; width: 100%; }
+}
+
+@media (min-width: 2520px) {
+    .col-qhd { flex: 1 0 0%; }
+    .col-qhd-auto { flex: 0 0 auto; width: auto; }
+    .col-qhd-1 { flex: 0 0 auto; width: 8.33333333%; }
+    .col-qhd-2 { flex: 0 0 auto; width: 16.66666667%; }
+    .col-qhd-3 { flex: 0 0 auto; width: 25%; }
+    .col-qhd-4 { flex: 0 0 auto; width: 33.33333333%; }
+    .col-qhd-5 { flex: 0 0 auto; width: 41.66666667%; }
+    .col-qhd-6 { flex: 0 0 auto; width: 50%; }
+    .col-qhd-7 { flex: 0 0 auto; width: 58.33333333%; }
+    .col-qhd-8 { flex: 0 0 auto; width: 66.66666667%; }
+    .col-qhd-9 { flex: 0 0 auto; width: 75%; }
+    .col-qhd-10 { flex: 0 0 auto; width: 83.33333333%; }
+    .col-qhd-11 { flex: 0 0 auto; width: 91.66666667%; }
+    .col-qhd-12 { flex: 0 0 auto; width: 100%; }
+}
+
+@media (min-width: 3200px) {
+    .col-uhd { flex: 1 0 0%; }
+    .col-uhd-auto { flex: 0 0 auto; width: auto; }
+    .col-uhd-1 { flex: 0 0 auto; width: 8.33333333%; }
+    .col-uhd-2 { flex: 0 0 auto; width: 16.66666667%; }
+    .col-uhd-3 { flex: 0 0 auto; width: 25%; }
+    .col-uhd-4 { flex: 0 0 auto; width: 33.33333333%; }
+    .col-uhd-5 { flex: 0 0 auto; width: 41.66666667%; }
+    .col-uhd-6 { flex: 0 0 auto; width: 50%; }
+    .col-uhd-7 { flex: 0 0 auto; width: 58.33333333%; }
+    .col-uhd-8 { flex: 0 0 auto; width: 66.66666667%; }
+    .col-uhd-9 { flex: 0 0 auto; width: 75%; }
+    .col-uhd-10 { flex: 0 0 auto; width: 83.33333333%; }
+    .col-uhd-11 { flex: 0 0 auto; width: 91.66666667%; }
+    .col-uhd-12 { flex: 0 0 auto; width: 100%; }
 }

--- a/moo-ds/src/css/_moo-utilities.css
+++ b/moo-ds/src/css/_moo-utilities.css
@@ -64,7 +64,7 @@
     .d-xl-table-cell { display: table-cell !important; }
 }
 
-@media (min-width: 1400px) {
+@media (min-width: 1500px) {
     .d-xxl-none { display: none !important; }
     .d-xxl-block { display: block !important; }
     .d-xxl-flex { display: flex !important; }
@@ -75,6 +75,46 @@
     .d-xxl-table { display: table !important; }
     .d-xxl-table-row { display: table-row !important; }
     .d-xxl-table-cell { display: table-cell !important; }
+}
+
+/* Extended breakpoints: fhd 1880, qhd 2520, uhd 3200 (see _moo-grid.css). */
+@media (min-width: 1880px) {
+    .d-fhd-none { display: none !important; }
+    .d-fhd-block { display: block !important; }
+    .d-fhd-flex { display: flex !important; }
+    .d-fhd-inline { display: inline !important; }
+    .d-fhd-inline-flex { display: inline-flex !important; }
+    .d-fhd-inline-block { display: inline-block !important; }
+    .d-fhd-grid { display: grid !important; }
+    .d-fhd-table { display: table !important; }
+    .d-fhd-table-row { display: table-row !important; }
+    .d-fhd-table-cell { display: table-cell !important; }
+}
+
+@media (min-width: 2520px) {
+    .d-qhd-none { display: none !important; }
+    .d-qhd-block { display: block !important; }
+    .d-qhd-flex { display: flex !important; }
+    .d-qhd-inline { display: inline !important; }
+    .d-qhd-inline-flex { display: inline-flex !important; }
+    .d-qhd-inline-block { display: inline-block !important; }
+    .d-qhd-grid { display: grid !important; }
+    .d-qhd-table { display: table !important; }
+    .d-qhd-table-row { display: table-row !important; }
+    .d-qhd-table-cell { display: table-cell !important; }
+}
+
+@media (min-width: 3200px) {
+    .d-uhd-none { display: none !important; }
+    .d-uhd-block { display: block !important; }
+    .d-uhd-flex { display: flex !important; }
+    .d-uhd-inline { display: inline !important; }
+    .d-uhd-inline-flex { display: inline-flex !important; }
+    .d-uhd-inline-block { display: inline-block !important; }
+    .d-uhd-grid { display: grid !important; }
+    .d-uhd-table { display: table !important; }
+    .d-uhd-table-row { display: table-row !important; }
+    .d-uhd-table-cell { display: table-cell !important; }
 }
 
 .visually-hidden,

--- a/moo-ds/src/css/pages/_dashboard.css
+++ b/moo-ds/src/css/pages/_dashboard.css
@@ -16,7 +16,7 @@ main.dashboard {
             }
         }
 
-        @media (max-width: 1399.98px) {
+        @media (max-width: 1499.98px) {
             grid-template-columns: repeat(2, 1fr);
         }
 


### PR DESCRIPTION
## Summary

The grid and display utilities topped out at xxl (1400px), so everything from a 1400px window to a 4K monitor got the same layout — filter panels squashed at the bottom of the old scale, switches stretched across acres at the top.

New ladder: sm 576 · md 768 · lg 992 · xl 1200 · **xxl 1500** · **fhd 1880** · **qhd 2520** · **uhd 3200**

- Three display-derived breakpoints (Full HD / Quad HD / UHD-class, set ~40–80px under the screen width to allow for scrollbars) added to grid columns, container max-widths, `d-*` display utilities, and `Col` props (`fhd`/`qhd`/`uhd`).
- **xxl moves 1400 → 1500** (half-way between xl and fhd). Existing `col-xxl-*`/`d-xxl-*` usage now kicks in 100px later; the dashboard grid's 2-column cutoff moves with it.

## Testing

- New Col tests for the extended props (14/14 pass); moo-ds type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)