### PR TITLE
fix(moo-ds): sub-pixel tolerance and first-pill guarantee in pill fit

### DIFF
--- a/moo-ds/src/components/comboBox/ComboBoxPills.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxPills.tsx
@@ -7,6 +7,34 @@ import { ComboBoxSelectedItem as SelectedItem } from "./ComboBoxSelectedItem";
 const CHIP_RESERVE = 56;
 const INPUT_RESERVE = 100;
 
+// Measured widths carry sub-pixel noise: a content-hugged control's available
+// width can land a fraction of a pixel under the integer-rounded pill sum, and
+// that rounding must not tip a fitting row into the "+N more" collapse.
+const FIT_EPSILON = 1;
+
+// Greedy fit of pill widths onto one row. Exported for unit tests (jsdom has
+// no layout, so the measuring effect itself cannot be exercised there).
+export const computePillFit = (widths: number[], avail: number, gap: number, inputReserve: number): number => {
+    if (widths.length === 0) return 0;
+
+    const totalAll = widths.reduce((sum, w, i) => sum + w + (i ? gap : 0), 0);
+    if (totalAll + inputReserve <= avail + FIT_EPSILON) return widths.length;
+
+    const reserve = CHIP_RESERVE + gap + inputReserve;
+    let used = 0;
+    let fitCount = 0;
+    for (let i = 0; i < widths.length; i++) {
+        const add = widths[i] + (fitCount ? gap : 0);
+        if (used + add + reserve > avail + FIT_EPSILON) break;
+        used += add;
+        fitCount++;
+    }
+
+    // Never collapse to a bare "+N more" with no pills at all — the first pill
+    // always shows, clipped by the body's overflow if it truly cannot fit.
+    return Math.max(1, fitCount);
+};
+
 // Renders the multi-select pills on a single row: as many as fit, then a
 // "+N more" chip for the rest. When the dropdown is open, room is also kept for
 // the input so the control never grows past one line — managing the full set
@@ -50,7 +78,10 @@ export const ComboBoxPills = () => {
 
         const pills = Array.from(wrap.querySelectorAll<HTMLElement>(".item"));
         const style = getComputedStyle(body);
-        const avail = body.clientWidth - parseFloat(style.paddingLeft || "0") - parseFloat(style.paddingRight || "0");
+        // Fractional widths throughout: clientWidth/offsetWidth round to
+        // integers, which combined with sub-pixel layout put a content-hugged
+        // control right on the fit boundary.
+        const avail = body.getBoundingClientRect().width - parseFloat(style.paddingLeft || "0") - parseFloat(style.paddingRight || "0");
 
         // No layout available (e.g. jsdom): show every pill.
         if (pills.length === 0 || !avail) {
@@ -60,26 +91,10 @@ export const ComboBoxPills = () => {
         }
 
         const gap = parseFloat(style.columnGap || style.gap) || 12;
-        const widths = pills.map(el => el.offsetWidth);
+        const widths = pills.map(el => el.getBoundingClientRect().width);
         const inputReserve = show ? INPUT_RESERVE + gap : 0;
 
-        const totalAll = widths.reduce((sum, w, i) => sum + w + (i ? gap : 0), 0);
-        if (totalAll + inputReserve <= avail) {
-            setFit(pills.length);
-            setMeasuring(false);
-            return;
-        }
-
-        const reserve = CHIP_RESERVE + gap + inputReserve;
-        let used = 0;
-        let fitCount = 0;
-        for (let i = 0; i < widths.length; i++) {
-            const add = widths[i] + (fitCount ? gap : 0);
-            if (used + add + reserve > avail) break;
-            used += add;
-            fitCount++;
-        }
-        setFit(fitCount);
+        setFit(computePillFit(widths, avail, gap, inputReserve));
         setMeasuring(false);
     }, [measuring, count, show]);
 

--- a/moo-ds/src/components/comboBox/ComboBoxPills.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxPills.tsx
@@ -84,7 +84,7 @@ export const ComboBoxPills = () => {
         const avail = body.getBoundingClientRect().width - parseFloat(style.paddingLeft || "0") - parseFloat(style.paddingRight || "0");
 
         // No layout available (e.g. jsdom): show every pill.
-        if (pills.length === 0 || !avail) {
+        if (pills.length === 0 || !Number.isFinite(avail) || avail <= 0) {
             setFit(pills.length);
             setMeasuring(false);
             return;

--- a/moo-ds/src/components/comboBox/__tests__/ComboBoxPills.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBoxPills.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { computePillFit } from '../ComboBoxPills';
+
+describe('computePillFit', () => {
+  it('keeps every pill when they all fit', () => {
+    // 100 + 10 + 100 = 210 exactly
+    expect(computePillFit([100, 100], 210, 10, 0)).toBe(2);
+  });
+
+  it('tolerates sub-pixel rounding at the exact boundary', () => {
+    // Integer-rounded pill widths sum to 251 while the fractional available
+    // width is 250.5 — a content-hugged control lands here and must not
+    // collapse into the "+N more" chip.
+    expect(computePillFit([84, 84, 83], 250.5, 0, 0)).toBe(3);
+  });
+
+  it('reserves room for the input while the dropdown is open', () => {
+    // All would fit closed (200 <= 200), but the open input reserve pushes
+    // the row into chip mode.
+    expect(computePillFit([95, 95], 200, 10, 110)).toBeLessThan(2);
+  });
+
+  it('drops overflowing pills behind the chip, keeping the ones that fit', () => {
+    // total 100+10+100+10+100 = 320 > 240; chip reserve 56+10 leaves the
+    // first pill (100 + 66 <= 240) and the second (210 + 66 > 240 breaks).
+    expect(computePillFit([100, 100, 100], 240, 10, 0)).toBe(1);
+  });
+
+  it('never collapses to zero pills — the first pill always shows', () => {
+    expect(computePillFit([300], 100, 10, 0)).toBe(1);
+    expect(computePillFit([300, 300], 100, 10, 0)).toBe(1);
+  });
+
+  it('returns zero only for an empty pill list', () => {
+    expect(computePillFit([], 240, 10, 0)).toBe(0);
+  });
+});


### PR DESCRIPTION
Found via Wrangler's dashboard branch filter: with 3 branches selected the pills needed 251px against 250.5px available — integer-rounded pill widths vs fractional available width collapsed a perfectly fitting row to a bare '+N more' chip. Any content-hugged control sits exactly on this boundary.

- Measure pills and the row fractionally via getBoundingClientRect
- 1px epsilon in the fit comparisons
- Guarantee the first pill always renders in chip mode (no more zero-pill '+N more')
- Fit logic extracted as computePillFit + unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)