### PR TITLE
fix(combo-box): don't reveal the input when peeking via the chevron

### DIFF
--- a/moo-ds/src/components/comboBox/ComboBoxInput.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxInput.tsx
@@ -4,7 +4,7 @@ import { useInnerRef } from "../../hooks";
 
 export const ComboBoxInput = ({ placeholder, ...props }: ComboBoxInputProps) => {
 
-    const { createLabel, creatable, allItems, labelField, search, setItems, selectedItems, newItem, setNewItem, show, text, setText, setShow, ref, listId } = useComboBox();
+    const { createLabel, creatable, allItems, labelField, search, setItems, selectedItems, newItem, setNewItem, show, showInput, text, setText, setShow, ref, listId } = useComboBox();
 
     // Debounce the actual search execution. Previously `useDebounce(search, 300)`
     // debounced the function *value* (a stable reference), so the search ran
@@ -71,9 +71,12 @@ export const ComboBoxInput = ({ placeholder, ...props }: ComboBoxInputProps) => 
         }
     }
 
-    // While the dropdown is closed the selected pills stand in for the input;
-    // opening it reveals the input for typing/searching.
-    const inputVisible = selectedItems?.length === 0 || !!show;
+    // While the dropdown is closed the selected pills stand in for the input.
+    // The input is only revealed when the user opens the control to type/search
+    // (body click sets showInput) -- not when merely peeking via the chevron,
+    // which would add the input to the row and resize the control. With nothing
+    // selected there are no pills, so the input is always shown.
+    const inputVisible = selectedItems?.length === 0 || (!!show && !!showInput);
 
     const innerRef = useInnerRef<HTMLInputElement>(ref);
 

--- a/moo-ds/src/components/comboBox/__tests__/ComboBoxContainer.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBoxContainer.test.tsx
@@ -117,6 +117,31 @@ describe('ComboBoxContainer', () => {
 
       expect(screen.getByText('Item 1')).toBeInTheDocument();
     });
+
+    it('opens the dropdown without revealing the input when the chevron is clicked', () => {
+      const { container } = renderWithProvider({}, { selectedItems: [items[0]], multiSelect: true });
+
+      // Pills stand in for the input while it is collapsed.
+      expect(container.querySelector('input')).toHaveAttribute('hidden');
+
+      // Clicking the chevron opens the list to peek at the options...
+      fireEvent.click(container.querySelector('.drop-down-chevron')!);
+      expect(container.querySelector('.cb-list')).toBeInTheDocument();
+
+      // ...but must NOT un-hide the text input, which would grow the control.
+      expect(container.querySelector('input')).toHaveAttribute('hidden');
+    });
+
+    it('reveals the input when the body is clicked', () => {
+      const { container } = renderWithProvider({}, { selectedItems: [items[0]], multiSelect: true });
+
+      expect(container.querySelector('input')).toHaveAttribute('hidden');
+
+      // Clicking the body (to type/search) opens the list and reveals the input.
+      fireEvent.click(container.querySelector('.body')!);
+      expect(container.querySelector('.cb-list')).toBeInTheDocument();
+      expect(container.querySelector('input')).not.toHaveAttribute('hidden');
+    });
   });
 
   describe('single-select mode', () => {


### PR DESCRIPTION
## Summary

With items selected, clicking the chevron to open the dropdown also un-hid the text input next to the pills, and its `min-width: 100px` grew the control on a single-row body — an unexpected resize.

Root cause: `ComboBoxInput` keyed visibility off `show` (is the list open). A separate `showInput` state exists precisely to mean "reveal the input" and is set **only** by a body click — the chevron's `toggle` deliberately sets just `show` — but the input had been rewired to `show`, so the chevron revealed it anyway.

Fix: key visibility on `show && showInput`.

- **Chevron** → opens the list to peek, input stays hidden, no resize.
- **Body click** → opens the list *and* reveals the input for typing/searching (unchanged).
- Every close path already flips `show` false, so no extra state resets are needed.

## Testing

- Two new container tests: chevron opens the list without un-hiding the input; body click reveals it. The chevron test fails on the old code, passes on the fix.
- Full moo-ds suite green (1,308 tests); type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)