### PR TITLE
fix(combo-box): clear the search input after selecting in multi-select

### DIFF
--- a/moo-ds/src/components/comboBox/ComboBoxList.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxList.tsx
@@ -3,7 +3,7 @@ import { useComboBox } from "./ComboBoxProvider";
 
 export const ComboBoxList = () => {
 
-    const { creatable, items, multiSelect, onAdd, onRemove, onChange, onCreate, show, setShow, newItem, setNewItem, selectedItems, setSelectedItems, setText, text, valueField, listId } = useComboBox();
+    const { creatable, items, setItems, allItems, multiSelect, onAdd, onRemove, onChange, onCreate, show, setShow, newItem, setNewItem, selectedItems, setSelectedItems, setText, text, valueField, listId } = useComboBox();
 
     if (!show) return null;
 
@@ -22,7 +22,7 @@ export const ComboBoxList = () => {
         }
 
         // Multi-select: the row is a checkbox. Toggle it and keep the dropdown
-        // open so the user can pick several. The text filter is left intact.
+        // open so the user can pick several.
         const selected = isSelected(item);
         const newSelectedItems = selected
             ? selectedItems.filter(i => valueField(i) !== valueField(item))
@@ -33,6 +33,12 @@ export const ComboBoxList = () => {
 
         setSelectedItems(newSelectedItems);
         onChange?.(newSelectedItems);
+
+        // Clear the search after a pick so the input is empty and ready for the
+        // next one; reset the filter to the full list too, otherwise an empty
+        // input would still show the stale narrowed results.
+        setText("");
+        setItems(allItems);
     }
 
     const onItemCreated = () => {

--- a/moo-ds/src/components/comboBox/__tests__/ComboBoxList.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBoxList.test.tsx
@@ -155,6 +155,39 @@ describe('ComboBoxList', () => {
       expect(onChange).toHaveBeenCalledWith([]);
     });
 
+    it('clears the search text after selecting in multi-select mode', () => {
+      const { container } = renderWithContainer({ multiSelect: true });
+
+      fireEvent.click(container.querySelector('.combo-box')!);
+
+      // Type to filter down to a single option, then pick it.
+      const input = container.querySelector('input')!;
+      fireEvent.change(input, { target: { value: 'Item 1' } });
+      expect(input).toHaveValue('Item 1');
+
+      fireEvent.click(screen.getByText('Item 1'));
+
+      // The input must clear so the user can search for the next item.
+      expect(input).toHaveValue('');
+    });
+
+    it('resets the filtered list after selecting in multi-select mode', () => {
+      const { container } = renderWithContainer({ multiSelect: true });
+
+      fireEvent.click(container.querySelector('.combo-box')!);
+
+      const input = container.querySelector('input')!;
+      fireEvent.change(input, { target: { value: 'Item 1' } });
+      // Filtered down to just Item 1.
+      expect(container.querySelectorAll('.cb-list li.cb-option').length).toBe(1);
+
+      fireEvent.click(screen.getByText('Item 1'));
+
+      // With the text cleared the full list must be shown again, not the stale
+      // single-item filter.
+      expect(container.querySelectorAll('.cb-list li.cb-option').length).toBe(3);
+    });
+
     it('pins selected items to the top of the list', () => {
       const { container } = renderWithContainer({ multiSelect: true, selectedItems: [items[2]] });
 


### PR DESCRIPTION
## Problem

In a multi-select ComboBox, typing to search then clicking an option left the typed text sitting in the input, and the list stayed narrowed to the old filter — so an empty-looking input still showed a filtered subset. Single-select already cleared the text on selection; multi-select did not.

## Fix

After each multi-select toggle, clear the search text and reset the filtered items back to the full list. The dropdown still stays open (it's a checklist), leaving the control in a neutral state ready to search for the next item.

## Tests

Two new `ComboBoxList` tests (type → filter → select):
- the input clears after selecting
- the filtered list resets to the full set

Full moo-ds suite: 1310 passed. Type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)