### PR TITLE
fix(combo-box): don't open an empty dropdown before there's anything to show

### DIFF
--- a/demoo/src/routes/ComboBox.tsx
+++ b/demoo/src/routes/ComboBox.tsx
@@ -1,6 +1,6 @@
 import { Page } from "@andrewmclachlan/moo-app";
 import { ComboBox, Section, SectionTable, TagPanel } from "@andrewmclachlan/moo-ds";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 type Tag = { id: number; text: string; colour: string };
 
@@ -18,6 +18,19 @@ export const ComboBoxPage = () => {
     const [few, setFew] = useState<Tag[]>(() => items.slice(4, 6));
     const [inCell, setInCell] = useState<Tag[]>(() => items.slice(0, 7));
     const [chromeless, setChromeless] = useState<Tag[]>(() => items.slice(2, 5));
+
+    // "Include tags" pattern: the dropdown only suggests tags that already exist
+    // (knownTags), and you type to include one that doesn't yet. Both start empty
+    // -- there is nothing to select until a tag is created.
+    const [knownTags, setKnownTags] = useState<Tag[]>([]);
+    const [included, setIncluded] = useState<Tag[]>([]);
+    const nextTagId = useRef(1000);
+
+    const createTag = (name: string) => {
+        const tag: Tag = { id: nextTagId.current++, text: name, colour: "#8b0000" };
+        setKnownTags((prev) => [...prev, tag]); // now a suggestion for next time
+        setIncluded((prev) => [...prev, tag]);  // and included straight away
+    };
 
     const common = {
         items,
@@ -47,6 +60,31 @@ export const ComboBoxPage = () => {
 
             <Section title="Few selections" header="Few selections (all fit, no chip)" headerSize={4}>
                 <ComboBox {...common} selectedItems={few} onChange={setFew} />
+            </Section>
+
+            <Section title="Creatable" header="Type to include, suggest from what exists (&ldquo;Include tags&hellip;&rdquo;)" headerSize={4}>
+                <p>
+                    The dropdown only suggests tags that already exist; you <em>type</em> to include
+                    one that doesn&rsquo;t. Starting empty (no tags yet), clicking the control shows
+                    <strong> no dropdown at all</strong> &mdash; there is nothing to select, and never
+                    will be until a tag exists, so there is no empty bar. Start typing and an
+                    &ldquo;Add &hellip;&rdquo; option appears; once added, the tag becomes a
+                    suggestion the next time you open it.
+                </p>
+                <ComboBox
+                    items={knownTags}
+                    labelField={(i: Tag) => i.text}
+                    valueField={(i: Tag) => i.id}
+                    multiSelect
+                    creatable
+                    clearable
+                    createLabel={(t: string) => `Add “${t}”`}
+                    onCreate={createTag}
+                    placeholder="Include tags..."
+                    className="cb-demo"
+                    selectedItems={included}
+                    onChange={setIncluded}
+                />
             </Section>
 
             <Section title="Chromeless" header="Chromeless until clicked (TagPanel)" headerSize={4}>

--- a/moo-ds/src/components/comboBox/ComboBoxInput.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxInput.tsx
@@ -4,7 +4,7 @@ import { useInnerRef } from "../../hooks";
 
 export const ComboBoxInput = ({ placeholder, ...props }: ComboBoxInputProps) => {
 
-    const { createLabel, creatable, allItems, labelField, search, setItems, selectedItems, newItem, setNewItem, show, showInput, text, setText, setShow, ref, listId } = useComboBox();
+    const { createLabel, creatable, allItems, labelField, search, setItems, selectedItems, newItem, setNewItem, show, showInput, showList, text, setText, setShow, ref, listId } = useComboBox();
 
     // Debounce the actual search execution. Previously `useDebounce(search, 300)`
     // debounced the function *value* (a stable reference), so the search ran
@@ -81,7 +81,7 @@ export const ComboBoxInput = ({ placeholder, ...props }: ComboBoxInputProps) => 
     const innerRef = useInnerRef<HTMLInputElement>(ref);
 
     return (
-        <input type="text" ref={innerRef} hidden={!inputVisible} placeholder={selectedItems?.length == 0 && !props.readonly ? placeholder : ""} onChange={onChange} onKeyUp={keyUp} value={text} tabIndex={props.tabIndex} autoCapitalize="off" autoComplete="off" autoCorrect="off" spellCheck={false} role="combobox" aria-expanded={!!show} aria-controls={listId} />
+        <input type="text" ref={innerRef} hidden={!inputVisible} placeholder={selectedItems?.length == 0 && !props.readonly ? placeholder : ""} onChange={onChange} onKeyUp={keyUp} value={text} tabIndex={props.tabIndex} autoCapitalize="off" autoComplete="off" autoCorrect="off" spellCheck={false} role="combobox" aria-expanded={showList} aria-controls={listId} />
     );
 }
 

--- a/moo-ds/src/components/comboBox/ComboBoxInput.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxInput.tsx
@@ -81,7 +81,7 @@ export const ComboBoxInput = ({ placeholder, ...props }: ComboBoxInputProps) => 
     const innerRef = useInnerRef<HTMLInputElement>(ref);
 
     return (
-        <input type="text" ref={innerRef} hidden={!inputVisible} placeholder={selectedItems?.length == 0 && !props.readonly ? placeholder : ""} onChange={onChange} onKeyUp={keyUp} value={text} tabIndex={props.tabIndex} autoCapitalize="off" autoComplete="off" autoCorrect="off" spellCheck={false} role="combobox" aria-expanded={showList} aria-controls={listId} />
+        <input type="text" ref={innerRef} hidden={!inputVisible} placeholder={selectedItems?.length == 0 && !props.readonly ? placeholder : ""} onChange={onChange} onKeyUp={keyUp} value={text} tabIndex={props.tabIndex} autoCapitalize="off" autoComplete="off" autoCorrect="off" spellCheck={false} role="combobox" aria-expanded={showList} aria-controls={showList ? listId : undefined} />
     );
 }
 

--- a/moo-ds/src/components/comboBox/ComboBoxList.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxList.tsx
@@ -3,9 +3,11 @@ import { useComboBox } from "./ComboBoxProvider";
 
 export const ComboBoxList = () => {
 
-    const { creatable, items, setItems, allItems, multiSelect, onAdd, onRemove, onChange, onCreate, show, setShow, newItem, setNewItem, selectedItems, setSelectedItems, setText, text, valueField, listId } = useComboBox();
+    const { creatable, items, setItems, allItems, multiSelect, onAdd, onRemove, onChange, onCreate, showList, setShow, newItem, setNewItem, selectedItems, setSelectedItems, setText, text, valueField, listId } = useComboBox();
 
-    if (!show) return null;
+    // Only render when there is content to show -- an empty, un-queried list
+    // stays closed rather than flashing an empty bar (see showList in provider).
+    if (!showList) return null;
 
     const isSelected = (item: any) => selectedItems.some(i => valueField(i) === valueField(item));
 

--- a/moo-ds/src/components/comboBox/ComboBoxProvider.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxProvider.tsx
@@ -52,8 +52,17 @@ export const ComboBoxProvider = <T,>(props: React.PropsWithChildren<ComboBoxProv
 
     const { clearable, creatable, multiSelect, readonly, labelField, valueField, colourField, onAdd, onRemove, onChange, onCreate, createLabel, search, ref } = props;
 
+    // Whether the dropdown panel actually has something worth showing. Opening
+    // the control is not enough: an empty, un-queried list (e.g. a search combo
+    // on first click, or a list whose items haven't loaded yet) shows no panel
+    // at all rather than an empty "No results" bar. The panel appears once there
+    // are items, a creatable "add" row, or a query has been typed (so an empty
+    // result is meaningful). This is the single source of truth for both the
+    // list's rendering and the input's aria-expanded state.
+    const showList = show && (items.length > 0 || (!!creatable && !!newItem) || text.length > 0);
+
     return (
-        <ComboBoxContext value={{ selectedItems, setSelectedItems, text, setText, items, setItems, newItem, setNewItem, show, setShow, showInput, setShowInput, clear, clearable, creatable, multiSelect, readonly, labelField, valueField, colourField, onAdd, onRemove, onChange, onCreate, createLabel, search, allItems, ref, listId }}>
+        <ComboBoxContext value={{ selectedItems, setSelectedItems, text, setText, items, setItems, newItem, setNewItem, show, setShow, showInput, setShowInput, showList, clear, clearable, creatable, multiSelect, readonly, labelField, valueField, colourField, onAdd, onRemove, onChange, onCreate, createLabel, search, allItems, ref, listId }}>
             {props.children}
         </ComboBoxContext>
     );
@@ -85,6 +94,8 @@ export interface ComboBoxOptions {
     setShow: (show: boolean) => void
     showInput: boolean;
     setShowInput: (show: boolean) => void;
+    /** True when the dropdown panel has content worth showing (see provider). */
+    showList: boolean;
     clear: (e: React.MouseEvent<any>) => void;
     clearable?: boolean;
     creatable?: boolean;

--- a/moo-ds/src/components/comboBox/ComboBoxProvider.tsx
+++ b/moo-ds/src/components/comboBox/ComboBoxProvider.tsx
@@ -7,7 +7,10 @@ export const ComboBoxProvider = <T,>(props: React.PropsWithChildren<ComboBoxProv
 
     const [selectedItems, setSelectedItems] = useState(props.selectedItems ? props.selectedItems : []);
     const [text, setText] = useState("");
-    const [items, setItems] = useState<T[]>(props.items);
+    // `items` is optional on the props; default to an empty array so consumers
+    // that omit it (e.g. a purely search-driven combo) never leave `items`
+    // undefined -- showList and the list rendering both read `items.length`.
+    const [items, setItems] = useState<T[]>(props.items ?? []);
     const [newItem, setNewItem] = useState(null as any);
     const [show, setShow] = useState(false);
     const [showInput, setShowInput] = useState(false);

--- a/moo-ds/src/components/comboBox/__tests__/ComboBoxContainer.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBoxContainer.test.tsx
@@ -152,6 +152,34 @@ describe('ComboBoxContainer', () => {
     });
   });
 
+  describe('accessibility', () => {
+    it('does not crash when opened without an items prop', () => {
+      const { container } = render(
+        <ComboBoxProvider selectedItems={[]} labelField={defaultProps.labelField} valueField={defaultProps.valueField}>
+          <ComboBoxContainer placeholder="Select..." />
+        </ComboBoxProvider>
+      );
+
+      // `items` is optional; opening must not throw even though it was omitted.
+      expect(() => fireEvent.click(container.querySelector('.combo-box')!)).not.toThrow();
+    });
+
+    it('sets aria-controls to the listbox id only when the list is shown', () => {
+      const { container } = renderWithProvider();
+
+      const input = container.querySelector('input')!;
+      // Collapsed: no listbox mounted, so no dangling aria-controls.
+      expect(input).not.toHaveAttribute('aria-controls');
+
+      fireEvent.click(container.querySelector('.combo-box')!);
+
+      const listbox = container.querySelector('[role="listbox"]')!;
+      expect(listbox).toBeInTheDocument();
+      expect(input).toHaveAttribute('aria-expanded', 'true');
+      expect(input).toHaveAttribute('aria-controls', listbox.id);
+    });
+  });
+
   describe('tabIndex', () => {
     it('passes tabIndex to input', () => {
       renderWithProvider({ tabIndex: 5 });

--- a/moo-ds/src/components/comboBox/__tests__/ComboBoxInput.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBoxInput.test.tsx
@@ -127,14 +127,14 @@ describe('ComboBoxInput', () => {
   });
 
   describe('accessibility', () => {
-    it('exposes aria-expanded and aria-controls on the combobox', () => {
+    it('exposes aria-expanded, collapsed, with no dangling aria-controls', () => {
       renderWithProvider();
 
       const input = screen.getByRole('combobox');
-      expect(input).toHaveAttribute('aria-expanded');
-      // aria-controls is a per-instance generated id (React useId), not a
-      // shared hard-coded value.
-      expect(input.getAttribute('aria-controls')).toBeTruthy();
+      expect(input).toHaveAttribute('aria-expanded', 'false');
+      // While collapsed the listbox isn't mounted, so aria-controls must not
+      // point at a non-existent element (invalid ARIA).
+      expect(input).not.toHaveAttribute('aria-controls');
     });
   });
 

--- a/moo-ds/src/components/comboBox/__tests__/ComboBoxList.test.tsx
+++ b/moo-ds/src/components/comboBox/__tests__/ComboBoxList.test.tsx
@@ -69,20 +69,75 @@ describe('ComboBoxList', () => {
     });
   });
 
-  describe('no results', () => {
-    it('shows no results message when items empty and not creatable', () => {
+  describe('empty dropdown', () => {
+    it('does not open a panel when empty and nothing has been typed', () => {
       const { container } = renderWithContainer({ items: [] });
 
       fireEvent.click(container.querySelector('.combo-box')!);
 
-      expect(screen.getByText('No results found')).toBeInTheDocument();
+      // Nothing to show yet: no empty bar. The click just focuses the input so
+      // the user can start typing (e.g. a search-driven combo on first click).
+      expect(container.querySelector('.cb-list')).not.toBeInTheDocument();
     });
 
-    it('has no-results class on empty message', () => {
-      const { container } = renderWithContainer({ items: [] });
+    it('does not open a panel for a list that is empty until items arrive', () => {
+      const { container, rerender } = render(
+        <ComboBoxProvider {...defaultProps} items={[]}>
+          <ComboBoxContainer placeholder="Select..." />
+        </ComboBoxProvider>
+      );
+
+      fireEvent.click(container.querySelector('.combo-box')!);
+      expect(container.querySelector('.cb-list')).not.toBeInTheDocument();
+
+      // Items become available (e.g. loaded asynchronously): the panel appears.
+      rerender(
+        <ComboBoxProvider {...defaultProps} items={items}>
+          <ComboBoxContainer placeholder="Select..." />
+        </ComboBoxProvider>
+      );
+      fireEvent.click(container.querySelector('.combo-box')!);
+      expect(container.querySelector('.cb-list')).toBeInTheDocument();
+    });
+
+    it('does not open an empty bar for a creatable combo with no items (the "Include tags…" case)', () => {
+      const { container } = renderWithContainer({
+        items: [],
+        creatable: true,
+        onCreate: vi.fn(),
+        createLabel: (t: string) => `Add "${t}"`,
+      });
 
       fireEvent.click(container.querySelector('.combo-box')!);
 
+      // No existing tags to suggest and nothing typed: the dropdown must not
+      // render a stray empty <ol> bar.
+      expect(container.querySelector('.cb-list')).not.toBeInTheDocument();
+    });
+
+    it('shows the "Add" option once the user types in an empty creatable combo', () => {
+      const { container } = renderWithContainer({
+        items: [],
+        creatable: true,
+        onCreate: vi.fn(),
+        createLabel: (t: string) => `Add "${t}"`,
+      });
+
+      fireEvent.click(container.querySelector('.combo-box')!);
+      fireEvent.change(container.querySelector('input')!, { target: { value: 'release' } });
+
+      // Typing a free-text value is the point: the create affordance appears.
+      expect(screen.getByText('Add "release"')).toBeInTheDocument();
+    });
+
+    it('shows "No results found" once a query matches nothing', () => {
+      const { container } = renderWithContainer();
+
+      fireEvent.click(container.querySelector('.combo-box')!);
+      fireEvent.change(container.querySelector('input')!, { target: { value: 'zzz' } });
+
+      // A query has been entered, so the empty result is now meaningful.
+      expect(screen.getByText('No results found')).toBeInTheDocument();
       expect(container.querySelector('.no-results')).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Problem

Clicking a ComboBox always opened the dropdown, even when there was nothing to show. For a creatable combo with no existing items (e.g. an "Include tags…" control with no tags yet), this rendered a stray **empty bar** — `show` is true, but with zero items, nothing typed, and `creatable` suppressing the "No results found" row, the panel had no children.

The list source in that pattern is synchronous suggestions derived from current data — empty is a legitimate, permanent state, so an empty bar is pure noise.

## Fix

Gate the panel on having content worth showing (single source of truth in the provider):

```
showList = show && (items.length > 0 || (creatable && newItem) || text.length > 0)
```

- **Items present** → opens with the list, as before.
- **Empty + nothing typed** → no panel; the click just focuses the input.
- **Typed a query that matches nothing** → "No results found" (now meaningful).
- **Creatable, typing** → the "Add …" row appears.

`aria-expanded` now tracks `showList` too, so the combobox never reports expanded with no popup.

## Tests

New `ComboBoxList` cases: no panel when empty + unqueried, no panel for a list empty until items arrive, the creatable "Include tags…" case (no bar on click / "Add …" once you type), and "No results found" only after a non-matching query. Full moo-ds suite: 140 ComboBox tests, all green. Type-check clean.

## demoo

Adds a **creatable "Include tags…"** sample modelling the real pattern — suggestions from tags that already exist, type to add new ones, empty opens nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
