### PR TITLE
ci: disable Azure SWA per-PR preview deployments

### DIFF
--- a/.github/workflows/azure-static-web-apps-salmon-beach-014f72600.yml
+++ b/.github/workflows/azure-static-web-apps-salmon-beach-014f72600.yml
@@ -1,22 +1,21 @@
 name: Azure Static Web Apps CI/CD
 
+# Production deploys only. Per-PR preview environments are intentionally
+# disabled: the Azure SWA deploy action was failing on PRs (it left the
+# workspace .git root-owned, breaking checkout's post-cleanup), and PRs are
+# already validated by the Build and Publish workflow. Deploy runs on merge to
+# main (or a manual dispatch).
 on:
   workflow_dispatch:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - main
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
@@ -48,16 +47,3 @@ jobs:
           ###### End of Repository/Build Configurations ######
         env:
           SKIP_DEPLOY_ON_MISSING_SECRETS: true
-
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request Job
-    steps:
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          app_location: "/"
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_SALMON_BEACH_014F72600 }}
-          action: "close"

--- a/.github/workflows/azure-static-web-apps-salmon-beach-014f72600.yml
+++ b/.github/workflows/azure-static-web-apps-salmon-beach-014f72600.yml
@@ -37,7 +37,6 @@ jobs:
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_SALMON_BEACH_014F72600 }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig


### PR DESCRIPTION
Turns off the Azure Static Web Apps per-PR **preview** deployments, which have been the source of the red "Build and Deploy Job" on PRs (most recently dependabot #664).

### Why
On `pull_request` the SWA deploy action spins up a preview environment, but the action leaves the workspace `.git` root-owned, so `actions/checkout`'s post-cleanup fails with `could not lock config file .git/config: Permission denied` and the job goes red — after the app has already built successfully. PRs are already fully validated by the **Build and Publish** workflow (`npm ci` + `npm run test:run` + build), so the preview only adds a flaky failure with no extra coverage.

### Change
`azure-static-web-apps-salmon-beach-014f72600.yml` now deploys on **merge to `main`** (or manual `workflow_dispatch`) only:
- remove the `pull_request` trigger (no more preview environments)
- remove the build job's PR-specific `if` guard (only push / dispatch remain)
- remove the now-unused `close_pull_request_job` (its sole purpose was tearing down previews)
- reduce `permissions` to `contents: read` (no PR comments are produced anymore)

Production deploys on `main` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)