### PR TITLE
feat(demoo): samples for InputGroup, TextArea, SortableTh

### DIFF
--- a/demoo/src/routes/data/Table.tsx
+++ b/demoo/src/routes/data/Table.tsx
@@ -14,6 +14,14 @@ const people = [
 ];
 type Person = typeof people[number];
 
+// Typed column list keeps the sort field constrained to real keys of Person,
+// so there's no unchecked cast when SortableTh hands back a field string.
+const columns: { field: keyof Person; header: string }[] = [
+    { field: "name", header: "Name" },
+    { field: "role", header: "Role" },
+    { field: "logins", header: "Logins" },
+];
+
 export const TablePage = () => {
 
     const [tableValue, setTableValue] = useState<string | undefined>("Row 1 Data 1");
@@ -24,9 +32,10 @@ export const TablePage = () => {
     const [sortDirection, setSortDirection] = useState<SortDirection>("Ascending");
 
     const sort = (field: string) => {
-        const nextDir = field === sortField ? changeSortDirection(sortDirection) : "Ascending";
-        setSortField(field as keyof Person);
-        setSortDirection(nextDir);
+        const column = columns.find((c) => c.field === field);
+        if (!column) return;
+        setSortField(column.field);
+        setSortDirection(column.field === sortField ? changeSortDirection(sortDirection) : "Ascending");
     };
 
     const sortedPeople = [...people].sort((a, b) => {
@@ -116,9 +125,9 @@ export const TablePage = () => {
             <SectionTable header="Sortable columns (SortableTh)" striped hover headerSize={4}>
                 <thead>
                     <tr>
-                        <SortableTh field="name" sortField={sortField} sortDirection={sortDirection} onSort={sort}>Name</SortableTh>
-                        <SortableTh field="role" sortField={sortField} sortDirection={sortDirection} onSort={sort}>Role</SortableTh>
-                        <SortableTh field="logins" sortField={sortField} sortDirection={sortDirection} onSort={sort}>Logins</SortableTh>
+                        {columns.map((c) => (
+                            <SortableTh key={c.field} field={c.field} sortField={sortField} sortDirection={sortDirection} onSort={sort}>{c.header}</SortableTh>
+                        ))}
                     </tr>
                 </thead>
                 <tbody>

--- a/demoo/src/routes/data/Table.tsx
+++ b/demoo/src/routes/data/Table.tsx
@@ -1,15 +1,38 @@
 import { Page } from "@andrewmclachlan/moo-app";
-import { Section, SectionTable, EditColumn, Button } from "@andrewmclachlan/moo-ds";
+import { Section, SectionTable, EditColumn, SortableTh, changeSortDirection, type SortDirection, Button } from "@andrewmclachlan/moo-ds";
 import { useState } from "react";
 import { dataNav } from "../../nav";
 
 const rows = Array.from({ length: 6 }, (_, i) => ({ a: `Row ${i + 1} Data 1`, b: `Row ${i + 1} Data 2`, c: `Row ${i + 1} Data 3` }));
+
+const people = [
+    { name: "Alice", role: "Admin", logins: 42 },
+    { name: "Bob", role: "Editor", logins: 17 },
+    { name: "Charlie", role: "Viewer", logins: 8 },
+    { name: "Diana", role: "Editor", logins: 31 },
+    { name: "Eve", role: "Admin", logins: 25 },
+];
+type Person = typeof people[number];
 
 export const TablePage = () => {
 
     const [tableValue, setTableValue] = useState<string | undefined>("Row 1 Data 1");
     const [tableNumValue, setTableNumValue] = useState<number | undefined>(1);
     const [isTableLoading, setIsTableLoading] = useState(false);
+
+    const [sortField, setSortField] = useState<keyof Person>("name");
+    const [sortDirection, setSortDirection] = useState<SortDirection>("Ascending");
+
+    const sort = (field: string) => {
+        const nextDir = field === sortField ? changeSortDirection(sortDirection) : "Ascending";
+        setSortField(field as keyof Person);
+        setSortDirection(nextDir);
+    };
+
+    const sortedPeople = [...people].sort((a, b) => {
+        const dir = sortDirection === "Ascending" ? 1 : -1;
+        return a[sortField] < b[sortField] ? -dir : a[sortField] > b[sortField] ? dir : 0;
+    });
 
     const simulateLoading = () => {
         setIsTableLoading(true);
@@ -85,6 +108,25 @@ export const TablePage = () => {
                             <td>{row.a}</td>
                             <td>{row.b}</td>
                             <td>{row.c}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </SectionTable>
+
+            <SectionTable header="Sortable columns (SortableTh)" striped hover headerSize={4}>
+                <thead>
+                    <tr>
+                        <SortableTh field="name" sortField={sortField} sortDirection={sortDirection} onSort={sort}>Name</SortableTh>
+                        <SortableTh field="role" sortField={sortField} sortDirection={sortDirection} onSort={sort}>Role</SortableTh>
+                        <SortableTh field="logins" sortField={sortField} sortDirection={sortDirection} onSort={sort}>Logins</SortableTh>
+                    </tr>
+                </thead>
+                <tbody>
+                    {sortedPeople.map((p) => (
+                        <tr key={p.name}>
+                            <td>{p.name}</td>
+                            <td>{p.role}</td>
+                            <td>{p.logins}</td>
                         </tr>
                     ))}
                 </tbody>

--- a/demoo/src/routes/forms/Form.tsx
+++ b/demoo/src/routes/forms/Form.tsx
@@ -9,6 +9,7 @@ interface FormSampleValues {
     group3: string[];
     group4: string;
     group5: string;
+    group6: string;
 }
 
 const selectItems = Array.from({ length: 10 }, (_, i) => ({ id: `${i + 1}`, text: `Option ${i + 1}` }));
@@ -21,6 +22,7 @@ export const FormPage = () => {
         group3: ["1", "2"],
         group4: "2",
         group5: "3",
+        group6: "A longer, multi-line note to check the label lines up with the first line of the textarea.",
     };
 
     const form = useForm<FormSampleValues>({ defaultValues: existing });
@@ -59,6 +61,10 @@ export const FormPage = () => {
                 <Form.Group groupId="group5">
                     <Form.Label>Input 5 (single-select)</Form.Label>
                     <FormComboBox<{ id: string, text: string }> items={selectItems} labelField={i => i.text} valueField={i => i.id} clearable />
+                </Form.Group>
+                <Form.Group groupId="group6">
+                    <Form.Label>Notes (textarea)</Form.Label>
+                    <Form.TextArea rows={4} placeholder="Multi-line notes" />
                 </Form.Group>
                 <Button type="submit" variant="primary">Submit</Button>
             </SectionForm>

--- a/demoo/src/routes/forms/Inputs.tsx
+++ b/demoo/src/routes/forms/Inputs.tsx
@@ -1,5 +1,5 @@
 import { Page } from "@andrewmclachlan/moo-app";
-import { Section, Input, Password, SearchBox } from "@andrewmclachlan/moo-ds";
+import { Section, Input, InputGroup, Password, SearchBox } from "@andrewmclachlan/moo-ds";
 import { useState } from "react";
 import { formsNav } from "../../nav";
 
@@ -16,6 +16,25 @@ export const Inputs = () => {
                     <Input placeholder="Plain input" />
                     <Input placeholder="Clearable input" clearable defaultValue="Clear me" />
                     <Input placeholder="Disabled" disabled />
+                </div>
+            </Section>
+
+            <Section title="Input group" header="InputGroup" headerSize={4}>
+                <p>Wraps an input with leading or trailing addons &mdash; use <code>InputGroup.Text</code> for a static prefix/suffix like a currency symbol, unit or handle.</p>
+                <div className="demo-col">
+                    <InputGroup>
+                        <InputGroup.Text>@</InputGroup.Text>
+                        <Input placeholder="username" />
+                    </InputGroup>
+                    <InputGroup>
+                        <InputGroup.Text>$</InputGroup.Text>
+                        <Input placeholder="0.00" type="number" />
+                        <InputGroup.Text>.00</InputGroup.Text>
+                    </InputGroup>
+                    <InputGroup>
+                        <Input placeholder="Search term" />
+                        <InputGroup.Text>.com</InputGroup.Text>
+                    </InputGroup>
                 </div>
             </Section>
 

--- a/demoo/src/routes/forms/Inputs.tsx
+++ b/demoo/src/routes/forms/Inputs.tsx
@@ -28,7 +28,7 @@ export const Inputs = () => {
                     </InputGroup>
                     <InputGroup>
                         <InputGroup.Text>$</InputGroup.Text>
-                        <Input placeholder="0.00" type="number" />
+                        <Input placeholder="0.00" type="number" step="0.01" />
                         <InputGroup.Text>.00</InputGroup.Text>
                     </InputGroup>
                     <InputGroup>


### PR DESCRIPTION
Fills the remaining public-component coverage gaps from the demoo showcase spec (#659). After the structure-first showcase (#667) landed, a sweep of every exported moo-ds/moo-app component against the demoo pages left only three genuinely user-facing components without a sample — everything else on the list is a compound-internal part (ComboBox/Section/Pagination pieces, icon primitives) already shown through its parent.

### Added
- **Inputs** page — an `InputGroup` section: prefix/suffix addons via `InputGroup.Text` (`@username`, `$ 0.00`, `search.com`).
- **Form** page — a Notes field using `Form.TextArea`, bound to the form state (TextArea is only public through `Form.TextArea`, so it lives with the other form controls).
- **Table** page — a sortable, non-paginated table using `SortableTh` with real client-side sorting, distinct from the paginated `SortablePaginationTh` already shown on the Pagination page.

### Verification
`tsc --noEmit` clean, `vite build` succeeds, no inline styles. Visual per the spec — run `npm run demoo` and open Forms → Inputs / Form and Data & Tables → Table.

Contributes to #659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)