### PR TITLE
fix(moo-app): stop auth recovery re-running queries it did not break

### DIFF
--- a/moo-app/src/MooApp.tsx
+++ b/moo-app/src/MooApp.tsx
@@ -8,6 +8,7 @@ import { AppProvider, MsalAuthProvider, isAuthCancellation } from "./providers";
 import { LinkProvider, MessageProvider, ThemeProvider } from "@andrewmclachlan/moo-ds";
 
 import getMsalInstance, { AUTH_RECOVERED_EVENT, type MsalOptions } from "./login/msal";
+import { brokenByAuthWindow } from "./login/authRecovery";
 
 import { MsalProvider } from "@azure/msal-react";
 import { type IPublicClientApplication } from "@azure/msal-browser";
@@ -19,20 +20,6 @@ import { type AxiosInstance } from "axios";
 
 
 library.add(faArrowRightFromBracket, faMoon, faSun, faTimesCircle);
-
-/**
- * Whether auth recovery should re-run a query: it failed, and it failed because the
- * auth window cancelled it rather than for a reason of its own.
- *
- * Matching on "failed" alone is not enough. Recovery fires on routine silent token
- * renewals, and every refetch acquires a token, so a query left failing for an
- * unrelated reason — a 5xx while the API is down — would be invalidated, refetch,
- * trigger another silent success, and be invalidated again, looping for as long as
- * the API stayed down. Testing the error keeps recovery doing its job while leaving
- * unrelated failures to surface as errors.
- */
-export const brokenByAuthWindow = (query: { state: { status: string; error: unknown } }): boolean =>
-  query.state.status === "error" && isAuthCancellation(query.state.error);
 
 export const MooApp: React.FC<PropsWithChildren<MooAppProps>> = ({ router, clientId, auth, scopes = [], client, name, version, copyrightYear, authFallback, queryPersistOptions, silentRedirectUri }) => {
 

--- a/moo-app/src/MooApp.tsx
+++ b/moo-app/src/MooApp.tsx
@@ -20,6 +20,20 @@ import { type AxiosInstance } from "axios";
 
 library.add(faArrowRightFromBracket, faMoon, faSun, faTimesCircle);
 
+/**
+ * Whether auth recovery should re-run a query: it failed, and it failed because the
+ * auth window cancelled it rather than for a reason of its own.
+ *
+ * Matching on "failed" alone is not enough. Recovery fires on routine silent token
+ * renewals, and every refetch acquires a token, so a query left failing for an
+ * unrelated reason — a 5xx while the API is down — would be invalidated, refetch,
+ * trigger another silent success, and be invalidated again, looping for as long as
+ * the API stayed down. Testing the error keeps recovery doing its job while leaving
+ * unrelated failures to surface as errors.
+ */
+export const brokenByAuthWindow = (query: { state: { status: string; error: unknown } }): boolean =>
+  query.state.status === "error" && isAuthCancellation(query.state.error);
+
 export const MooApp: React.FC<PropsWithChildren<MooAppProps>> = ({ router, clientId, auth, scopes = [], client, name, version, copyrightYear, authFallback, queryPersistOptions, silentRedirectUri }) => {
 
   const [msalInstance, setMsalInstance] = React.useState<IPublicClientApplication | null>(null);
@@ -66,11 +80,7 @@ export const MooApp: React.FC<PropsWithChildren<MooAppProps>> = ({ router, clien
 
   useEffect(() => {
     const onAuthRecovered = () => {
-      // Only refetch queries that actually failed. Recovery fires on silent token
-      // renewals too (which can happen routinely), so invalidating everything would
-      // cause a refetch storm; scoping to errored queries makes it a no-op unless a
-      // request was cancelled during an auth window (see login/msal.ts, Login gate).
-      queryClient.invalidateQueries({ predicate: (query) => query.state.status === "error" });
+      queryClient.invalidateQueries({ predicate: brokenByAuthWindow });
     };
 
     window.addEventListener(AUTH_RECOVERED_EVENT, onAuthRecovered);

--- a/moo-app/src/__tests__/authRecovery.test.ts
+++ b/moo-app/src/__tests__/authRecovery.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import axios from 'axios';
+import { brokenByAuthWindow } from '../MooApp';
+
+/** The marker the auth interceptors stamp on cancellations they raise. */
+const authCancellationMarker = Symbol.for("mooapp.authCancellation");
+
+const authCancellation = () =>
+  Object.assign(new axios.CanceledError("token refresh"), { [authCancellationMarker]: true });
+
+const query = (status: string, error: unknown) => ({ state: { status, error } });
+
+describe('brokenByAuthWindow', () => {
+
+  it('matches a query cancelled by the auth interceptor', () => {
+    // The case recovery exists for: the request was dropped mid auth window, so once a
+    // token lands the query has to be re-run or it stays failed forever.
+    expect(brokenByAuthWindow(query('error', authCancellation()))).toBe(true);
+  });
+
+  it('ignores a query that failed for a reason of its own', () => {
+    // A 5xx while the API is down. Re-running it would fail again, acquire another
+    // token, and fire recovery again — the loop this predicate exists to stop.
+    expect(brokenByAuthWindow(query('error', Object.assign(new Error('Bad Gateway'), { status: 502 })))).toBe(false);
+  });
+
+  it('ignores a cancellation the auth interceptors did not raise', () => {
+    // An ordinary abort — a component unmounting, a superseded request — is not an
+    // auth failure and has nothing to recover.
+    expect(brokenByAuthWindow(query('error', new axios.CanceledError('unmounted')))).toBe(false);
+  });
+
+  it('ignores queries that have not failed', () => {
+    expect(brokenByAuthWindow(query('success', undefined))).toBe(false);
+    expect(brokenByAuthWindow(query('pending', undefined))).toBe(false);
+  });
+
+  it('ignores a failed query with no error attached', () => {
+    expect(brokenByAuthWindow(query('error', undefined))).toBe(false);
+    expect(brokenByAuthWindow(query('error', null))).toBe(false);
+  });
+});

--- a/moo-app/src/__tests__/authRecovery.test.ts
+++ b/moo-app/src/__tests__/authRecovery.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import axios from 'axios';
-import { brokenByAuthWindow } from '../MooApp';
+import { brokenByAuthWindow } from "../login/authRecovery";
 
 /** The marker the auth interceptors stamp on cancellations they raise. */
 const authCancellationMarker = Symbol.for("mooapp.authCancellation");

--- a/moo-app/src/login/authRecovery.ts
+++ b/moo-app/src/login/authRecovery.ts
@@ -1,0 +1,18 @@
+import { isAuthCancellation } from "../providers";
+
+/**
+ * Whether auth recovery should re-run a query: it failed, and it failed because the
+ * auth window cancelled it rather than for a reason of its own.
+ *
+ * Matching on "failed" alone is not enough. Recovery fires on routine silent token
+ * renewals, and every refetch acquires a token, so a query left failing for an
+ * unrelated reason — a 5xx while the API is down — would be invalidated, refetch,
+ * trigger another silent success, and be invalidated again, looping for as long as
+ * the API stayed down. Testing the error keeps recovery doing its job while leaving
+ * unrelated failures to surface as errors.
+ *
+ * Internal: this module is deliberately not re-exported from `src/index.ts`, so the
+ * predicate stays out of the package's public API.
+ */
+export const brokenByAuthWindow = (query: { state: { status: string; error: unknown } }): boolean =>
+    query.state.status === "error" && isAuthCancellation(query.state.error);


### PR DESCRIPTION
With the API down, a consuming app sits in an endless request loop instead of showing an error. Measured in MooBank against a dev proxy with nothing behind it: **225 API requests in 10 seconds**, the same three requests cycling at roughly 570ms, for as long as the API stayed down.

## Cause

`onAuthRecovered` invalidated **every** errored query:

```ts
queryClient.invalidateQueries({ predicate: (query) => query.state.status === "error" });
```

Recovery fires on routine *silent* token renewals, not only after an interactive redirect (`login/msal.ts` deliberately includes `InteractionType.Silent`). So with a query failing for a reason of its own:

1. Silent token success → `mooapp:auth-recovered`
2. Listener invalidates the errored query
3. It refetches, acquiring a token on the way out
4. That silent success fires `auth-recovered` again → back to 1

Self-sustaining, and only reachable once a query is already failing — which is why it has gone unnoticed. Everything is fine while requests succeed.

The comment on the old predicate stated the assumption that doesn't hold:

> *"scoping to errored queries makes it a no-op unless a request was cancelled during an auth window"*

That's only true if `status === "error"` implies *stuck on auth*. A 502 is errored and has nothing to do with auth.

## Fix

Match on the auth cancellation itself, reusing the `isAuthCancellation` the retry policy on line 44 already trusts:

```ts
export const brokenByAuthWindow = (query) =>
  query.state.status === "error" && isAuthCancellation(query.state.error);
```

Queries dropped during an auth window still recover — that's what the mechanism was added for (#644) and it's unchanged. Failures of any other kind are left alone to surface as errors.

The predicate is exported so it can be tested directly; `MooApp` itself needs full MSAL mocking, which is why its existing tests are structural only.

## Testing

`moo-app/src/__tests__/authRecovery.test.ts` covers both directions and the edges:

- an auth-interceptor cancellation **is** recovered (the #644 case)
- a 502 is **not** — the loop this closes
- an ordinary abort (unmount, superseded request) is not treated as auth
- non-failed queries, and failed queries with no error attached

Not verified end to end against a live app — the loop needs a real MSAL token cycle to reproduce, so the evidence for the mechanism is the request trace above plus the unit coverage of the predicate.

## Downstream

MooBank hits this on any page that keeps errored queries mounted with active observers. It has no local workaround: `MooAppProps` exposes no way to configure the QueryClient. It'll need a version bump once this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
