### PR TITLE
fix(moo-app): repair type-check in MsalAuthProvider test

### DIFF
--- a/moo-app/src/providers/__tests__/MsalAuthProvider.test.tsx
+++ b/moo-app/src/providers/__tests__/MsalAuthProvider.test.tsx
@@ -282,7 +282,11 @@ describe('401 response recovery', () => {
     const calls: { auth: string | undefined }[] = [];
     client.defaults.adapter = async (config) => {
       const status = statuses.length > 1 ? statuses.shift()! : statuses[0];
-      calls.push({ auth: config.headers.getAuthorization() as unknown as string | undefined });
+      // getAuthorization() is typed as a union (string | string[] | RegExpExecArray | …);
+      // at runtime it's the "Bearer …" string when set, so narrow with a typeof guard
+      // rather than an unchecked cast.
+      const authorization = config.headers.getAuthorization();
+      calls.push({ auth: typeof authorization === 'string' ? authorization : undefined });
       const response = { data: {}, status, statusText: String(status), headers: {}, config } as any;
       if (status >= 400) {
         throw new axios.AxiosError(`Request failed with status code ${status}`, String(status), config as any, {}, response);

--- a/moo-app/src/providers/__tests__/MsalAuthProvider.test.tsx
+++ b/moo-app/src/providers/__tests__/MsalAuthProvider.test.tsx
@@ -282,7 +282,7 @@ describe('401 response recovery', () => {
     const calls: { auth: string | undefined }[] = [];
     client.defaults.adapter = async (config) => {
       const status = statuses.length > 1 ? statuses.shift()! : statuses[0];
-      calls.push({ auth: config.headers.getAuthorization() as string | undefined });
+      calls.push({ auth: config.headers.getAuthorization() as unknown as string | undefined });
       const response = { data: {}, status, statusText: String(status), headers: {}, config } as any;
       if (status >= 400) {
         throw new axios.AxiosError(`Request failed with status code ${status}`, String(status), config as any, {}, response);


### PR DESCRIPTION
`npm run type-check` was failing on `main`:

```
moo-app/src/providers/__tests__/MsalAuthProvider.test.tsx(285,26): error TS2352:
Conversion of type 'RegExpExecArray' to type 'string' may be a mistake because
neither type sufficiently overlaps with the other.
```

`AxiosHeaders.getAuthorization()` now types its return as including `RegExpExecArray` (an axios types change), which no longer overlaps with `string`, so the existing `as string | undefined` cast is rejected. Routed the cast through `unknown` as the compiler suggests. Runtime behaviour is unchanged.

**Why CI was green despite this:** the Build and Publish workflow runs vitest (esbuild transpile — no full type-check) and builds only the library sources, not the test files, so a type error confined to a test never surfaced there.

### Verification
- `npm run type-check` now passes (moo-ds + moo-app + moo-icons).
- `MsalAuthProvider.test.tsx`: 24/24 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)