### PR TITLE
refactor(moo-ds): collapse light/dark duplication with light-dark()

### DIFF
--- a/moo-ds/src/css/components/_alert.css
+++ b/moo-ds/src/css/components/_alert.css
@@ -38,136 +38,39 @@
     }
 }
 
+/* Variant tokens. light-dark() resolves against the inherited color-scheme,
+   which _variables.css sets on :root (light dark) and the .light/.dark and
+   [data-theme] theme classes force to a single scheme. That covers all four
+   cases -- OS light, OS dark, forced light, forced dark -- in one rule, so the
+   values no longer need to be repeated per theme.
+   First argument = light, second = dark. */
+
 .alert-danger {
-    --alert-colour: #842029;
-    --alert-bg: #f8d7da;
-    --alert-border-colour: #f5c2c7;
+    --alert-colour: light-dark(#842029, #ea868f);
+    --alert-bg: light-dark(#f8d7da, #2c0b0e);
+    --alert-border-colour: light-dark(#f5c2c7, #842029);
 }
 
 .alert-warning {
-    --alert-colour: #664d03;
-    --alert-bg: #fff3cd;
-    --alert-border-colour: #ffecb5;
+    --alert-colour: light-dark(#664d03, #ffda6a);
+    --alert-bg: light-dark(#fff3cd, #332701);
+    --alert-border-colour: light-dark(#ffecb5, #664d03);
 }
 
 .alert-success {
-    --alert-colour: #0f5132;
-    --alert-bg: #d1e7dd;
-    --alert-border-colour: #badbcc;
+    --alert-colour: light-dark(#0f5132, #75b798);
+    --alert-bg: light-dark(#d1e7dd, #051b11);
+    --alert-border-colour: light-dark(#badbcc, #0f5132);
 }
 
 .alert-info {
-    --alert-colour: #055160;
-    --alert-bg: #cff4fc;
-    --alert-border-colour: #b6effb;
+    --alert-colour: light-dark(#055160, #6edff6);
+    --alert-bg: light-dark(#cff4fc, #032830);
+    --alert-border-colour: light-dark(#b6effb, #055160);
 }
 
 .alert-primary {
-    --alert-colour: color-mix(in srgb, var(--primary) 60%, #000);
-    --alert-bg: color-mix(in srgb, var(--primary) 20%, #fff);
-    --alert-border-colour: color-mix(in srgb, var(--primary) 30%, #fff);
-}
-
-/* Light mode alert variants (explicit override when OS prefers dark) */
-.light .alert-danger,
-[data-theme="light"] .alert-danger {
-    --alert-colour: #842029;
-    --alert-bg: #f8d7da;
-    --alert-border-colour: #f5c2c7;
-}
-
-.light .alert-warning,
-[data-theme="light"] .alert-warning {
-    --alert-colour: #664d03;
-    --alert-bg: #fff3cd;
-    --alert-border-colour: #ffecb5;
-}
-
-.light .alert-success,
-[data-theme="light"] .alert-success {
-    --alert-colour: #0f5132;
-    --alert-bg: #d1e7dd;
-    --alert-border-colour: #badbcc;
-}
-
-.light .alert-info,
-[data-theme="light"] .alert-info {
-    --alert-colour: #055160;
-    --alert-bg: #cff4fc;
-    --alert-border-colour: #b6effb;
-}
-
-.light .alert-primary,
-[data-theme="light"] .alert-primary {
-    --alert-colour: color-mix(in srgb, var(--primary) 60%, #000);
-    --alert-bg: color-mix(in srgb, var(--primary) 20%, #fff);
-    --alert-border-colour: color-mix(in srgb, var(--primary) 30%, #fff);
-}
-
-/* Dark mode alert variants (prefers-color-scheme fallback) */
-@media (prefers-color-scheme: dark) {
-    .alert-danger {
-        --alert-colour: #ea868f;
-        --alert-bg: #2c0b0e;
-        --alert-border-colour: #842029;
-    }
-
-    .alert-warning {
-        --alert-colour: #ffda6a;
-        --alert-bg: #332701;
-        --alert-border-colour: #664d03;
-    }
-
-    .alert-success {
-        --alert-colour: #75b798;
-        --alert-bg: #051b11;
-        --alert-border-colour: #0f5132;
-    }
-
-    .alert-info {
-        --alert-colour: #6edff6;
-        --alert-bg: #032830;
-        --alert-border-colour: #055160;
-    }
-
-    .alert-primary {
-        --alert-colour: color-mix(in srgb, var(--primary) 40%, #fff);
-        --alert-bg: color-mix(in srgb, var(--primary) 20%, #000);
-        --alert-border-colour: color-mix(in srgb, var(--primary) 40%, #000);
-    }
-}
-
-.dark .alert-danger,
-[data-theme="dark"] .alert-danger {
-    --alert-colour: #ea868f;
-    --alert-bg: #2c0b0e;
-    --alert-border-colour: #842029;
-}
-
-.dark .alert-warning,
-[data-theme="dark"] .alert-warning {
-    --alert-colour: #ffda6a;
-    --alert-bg: #332701;
-    --alert-border-colour: #664d03;
-}
-
-.dark .alert-success,
-[data-theme="dark"] .alert-success {
-    --alert-colour: #75b798;
-    --alert-bg: #051b11;
-    --alert-border-colour: #0f5132;
-}
-
-.dark .alert-info,
-[data-theme="dark"] .alert-info {
-    --alert-colour: #6edff6;
-    --alert-bg: #032830;
-    --alert-border-colour: #055160;
-}
-
-.dark .alert-primary,
-[data-theme="dark"] .alert-primary {
-    --alert-colour: color-mix(in srgb, var(--primary) 40%, #fff);
-    --alert-bg: color-mix(in srgb, var(--primary) 20%, #000);
-    --alert-border-colour: color-mix(in srgb, var(--primary) 40%, #000);
+    --alert-colour: light-dark(color-mix(in srgb, var(--primary) 60%, #000), color-mix(in srgb, var(--primary) 40%, #fff));
+    --alert-bg: light-dark(color-mix(in srgb, var(--primary) 20%, #fff), color-mix(in srgb, var(--primary) 20%, #000));
+    --alert-border-colour: light-dark(color-mix(in srgb, var(--primary) 30%, #fff), color-mix(in srgb, var(--primary) 40%, #000));
 }

--- a/moo-ds/src/css/components/_badge.css
+++ b/moo-ds/src/css/components/_badge.css
@@ -44,51 +44,22 @@
     height: 1em;
 }
 
+/* Muted and outline both tint --badge-bg, but need more contrast against white
+   surfaces than dark ones. light-dark() resolves against the inherited
+   color-scheme (see _variables.css), so one rule covers OS light, OS dark and
+   both forced themes. First argument = light, second = dark. */
+
 /* Muted: tinted background, hue-as-text */
 .badge.muted {
-    background: color-mix(in srgb, var(--badge-bg) 25%, #000);
-    color: color-mix(in srgb, var(--badge-bg) 45%, #fff);
+    background: light-dark(color-mix(in srgb, var(--badge-bg) 16%, #fff), color-mix(in srgb, var(--badge-bg) 25%, #000));
+    color: light-dark(color-mix(in srgb, var(--badge-bg) 78%, #000), color-mix(in srgb, var(--badge-bg) 45%, #fff));
 }
 
 /* Outline: transparent background, hue ring (via inset shadow to avoid layout shift) + hue text */
 .badge.outline {
     background: transparent;
-    color: color-mix(in srgb, var(--badge-bg) 45%, #fff);
+    color: light-dark(color-mix(in srgb, var(--badge-bg) 78%, #000), color-mix(in srgb, var(--badge-bg) 45%, #fff));
     box-shadow: inset 0 0 0 1px var(--badge-bg);
-}
-
-/* Light-mode muted/outline overrides - more contrast against white surfaces */
-@media (prefers-color-scheme: light) {
-    .badge.muted {
-        background: color-mix(in srgb, var(--badge-bg) 16%, #fff);
-        color: color-mix(in srgb, var(--badge-bg) 78%, #000);
-    }
-
-    .badge.outline {
-        color: color-mix(in srgb, var(--badge-bg) 78%, #000);
-    }
-}
-
-.light .badge.muted,
-[data-theme="light"] .badge.muted {
-    background: color-mix(in srgb, var(--badge-bg) 16%, #fff);
-    color: color-mix(in srgb, var(--badge-bg) 78%, #000);
-}
-
-.light .badge.outline,
-[data-theme="light"] .badge.outline {
-    color: color-mix(in srgb, var(--badge-bg) 78%, #000);
-}
-
-.dark .badge.muted,
-[data-theme="dark"] .badge.muted {
-    background: color-mix(in srgb, var(--badge-bg) 25%, #000);
-    color: color-mix(in srgb, var(--badge-bg) 45%, #fff);
-}
-
-.dark .badge.outline,
-[data-theme="dark"] .badge.outline {
-    color: color-mix(in srgb, var(--badge-bg) 45%, #fff);
 }
 
 /* ---- Semantic background tokens ---- */

--- a/moo-ds/src/css/components/_forms.css
+++ b/moo-ds/src/css/components/_forms.css
@@ -73,9 +73,16 @@ textarea.form-control {
     min-height: calc(1.5em + 0.75rem + calc(var(--border-width, 1px) * 2));
 }
 
-/* Form select */
+/* Form select
+   The chevron is an SVG data URI, so its stroke colour cannot be swapped with
+   light-dark() (that only takes a <color>) and an SVG used as a background
+   image cannot read currentColor. Both variants are therefore declared once
+   here as tokens, and the theme rules below only re-point --form-select-bg-img
+   -- no data URI is repeated. */
 .form-select {
-    --form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3e%3cpath fill=%27none%27 stroke=%27%23343a40%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27 stroke-width=%272%27 d=%27m2 5 6 6 6-6%27/%3e%3c/svg%3e");
+    --form-select-chevron-light: url("data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3e%3cpath fill=%27none%27 stroke=%27%23343a40%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27 stroke-width=%272%27 d=%27m2 5 6 6 6-6%27/%3e%3c/svg%3e");
+    --form-select-chevron-dark: url("data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3e%3cpath fill=%27none%27 stroke=%27%23ced4da%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27 stroke-width=%272%27 d=%27m2 5 6 6 6-6%27/%3e%3c/svg%3e");
+    --form-select-bg-img: var(--form-select-chevron-light);
     display: block;
     width: 100%;
     padding: var(--input-padding-v, 0.375rem) calc(var(--input-padding-h, 0.75rem) + 16px) var(--input-padding-v, 0.375rem) var(--input-padding-h, 0.75rem);
@@ -111,18 +118,20 @@ option {
 
 @media (prefers-color-scheme: dark) {
     .form-select {
-        --form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3e%3cpath fill=%27none%27 stroke=%27%23ced4da%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27 stroke-width=%272%27 d=%27m2 5 6 6 6-6%27/%3e%3c/svg%3e");
+        --form-select-bg-img: var(--form-select-chevron-dark);
     }
 }
 
+/* Forced themes have to out-specify the media query above, so they stay as
+   explicit rules rather than folding into the base declaration. */
 .dark .form-select,
 [data-theme="dark"] .form-select {
-    --form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3e%3cpath fill=%27none%27 stroke=%27%23ced4da%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27 stroke-width=%272%27 d=%27m2 5 6 6 6-6%27/%3e%3c/svg%3e");
+    --form-select-bg-img: var(--form-select-chevron-dark);
 }
 
 .light .form-select,
 [data-theme="light"] .form-select {
-    --form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3e%3cpath fill=%27none%27 stroke=%27%23343a40%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27 stroke-width=%272%27 d=%27m2 5 6 6 6-6%27/%3e%3c/svg%3e");
+    --form-select-bg-img: var(--form-select-chevron-light);
 }
 
 /* Form label */
@@ -210,12 +219,18 @@ option {
     margin-right: 1rem;
 }
 
-/* Form switch */
+/* Form switch
+   Same data-URI constraint as the select chevron: the unchecked thumb needs a
+   dark circle on light surfaces and a light one on dark surfaces, so each
+   variant is declared once as a token and the theme rules re-point
+   --form-switch-bg. The checked thumb is white in both themes. */
 .form-switch {
     padding-left: 0;
 
     .form-check-input {
-        --form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba%280, 0, 0, 0.55%29'/%3e%3c/svg%3e");
+        --form-switch-thumb-light: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba%280, 0, 0, 0.55%29'/%3e%3c/svg%3e");
+        --form-switch-thumb-dark: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba%28255, 255, 255, 0.55%29'/%3e%3c/svg%3e");
+        --form-switch-bg: var(--form-switch-thumb-light);
         width: 2.8em;
         height: 1.5em;
         background-image: var(--form-switch-bg);
@@ -230,15 +245,26 @@ option {
     }
 }
 
-.dark .form-switch .form-check-input,
-[data-theme="dark"] .form-switch .form-check-input {
-    --form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba%28255, 255, 255, 0.55%29'/%3e%3c/svg%3e");
+/* Only the unchecked thumb is theme-dependent. Restricting these to
+   :not(:checked) also keeps them from out-ranking the :checked rule above:
+   `.dark .form-switch .form-check-input` and the nested
+   `.form-switch .form-check-input:checked` are both specificity (0,3,0), so
+   whichever comes last would otherwise win and a checked switch in a forced
+   theme would render the translucent thumb instead of the solid white one. */
+@media (prefers-color-scheme: dark) {
+    .form-switch .form-check-input:not(:checked) {
+        --form-switch-bg: var(--form-switch-thumb-dark);
+    }
 }
 
-@media (prefers-color-scheme: dark) {
-    .form-switch .form-check-input {
-        --form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba%28255, 255, 255, 0.55%29'/%3e%3c/svg%3e");
-    }
+.dark .form-switch .form-check-input:not(:checked),
+[data-theme="dark"] .form-switch .form-check-input:not(:checked) {
+    --form-switch-bg: var(--form-switch-thumb-dark);
+}
+
+.light .form-switch .form-check-input:not(:checked),
+[data-theme="light"] .form-switch .form-check-input:not(:checked) {
+    --form-switch-bg: var(--form-switch-thumb-light);
 }
 
 /* Form container */


### PR DESCRIPTION
First of the #657 workstreams (Tier 1.1) — the issue's nominated "ideal low-risk starter PR".

## What changed

Alert and badge variants were each declared **up to four times** — base, `.light`/`[data-theme=light]`, `@media (prefers-color-scheme: dark)` and `.dark`/`[data-theme=dark]` — with the values kept in sync by hand. `light-dark()` resolves against the inherited `color-scheme`, which `_variables.css` already sets on `:root` (`light dark`) and forces in the theme classes, so one rule now covers all four cases.

| File | Before | After |
|---|---|---|
| `_alert.css` | 173 | 76 |
| `_badge.css` | 118 | 89 |

No rendered colour changes — every value was carried across verbatim.

## `_forms.css` — the issue's premise doesn't hold here

#657 lists `_forms.css:112-126,233-241` under the same consolidation, but **those duplicated values are `url()` data URIs, not colours**, so `light-dark()` cannot apply to them (it only takes a `<color>`), and an SVG used as a background image cannot read `currentColor` either.

The actual defect there is the same 200-character data URI written out four times. Each chevron/switch-thumb variant is now declared **once** as a token, with the theme rules only re-pointing which token is used. The forced-theme selectors have to stay explicit because they need to out-specify the media query — but nothing is duplicated any more.

A proper fix that removes those rules altogether (mask-image, or rebuilding the thumb as a real CSS shape) belongs with the `accent-color` work in the polish PR, which touches the same visuals.

## Latent bug found and fixed

`.dark .form-switch .form-check-input` is specificity `(0,3,0)` — identical to the nested `.form-switch .form-check-input:checked` — and came **later** in source order, so it won. Under a **forced** dark theme a *checked* switch rendered the 55%-translucent thumb instead of solid white. OS-dark was unaffected because that selector is only `(0,2,0)`.

Confirmed by building the original `_forms.css` and reading the computed `background-image`:

```
forcedDark:  TRANSLUCENT (BUG PRESENT)
forcedLight: solid white (ok)
auto:        solid white (ok)
```

The theme rules are now scoped to `:not(:checked)`, which fixes it and prevents the mirror bug in forced light.

## Verification

Tests don't cover CSS, so correctness here is visual. Verified the built stylesheet in a harness rendering all three theme states, reading computed values rather than eyeballing:

| State | `.alert-danger` bg | chevron | unchecked thumb | checked thumb |
|---|---|---|---|---|
| unforced, OS dark | `rgb(44,11,14)` | `#ced4da` | white-translucent | **solid white** |
| unforced, OS light | `rgb(248,215,218)` | `#343a40` | black-translucent | **solid white** |
| forced light | `rgb(248,215,218)` | `#343a40` | black-translucent | **solid white** |
| forced dark | `rgb(44,11,14)` | `#ced4da` | white-translucent | **solid white** |

All match the pre-change values. Emulating `prefers-color-scheme` flips the unforced pane while leaving both forced panes fixed, confirming the forcing still overrides the OS.

- `npm run build -w @andrewmclachlan/moo-ds` — clean; `light-dark()` passes through Vite un-downlevelled
- `npm run test:run` — 1699/1699 pass (identical to baseline)

Refs #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)