### PR TITLE
refactor(moo-ds): keyboard-only focus rings, native checkbox tinting, scroll and wrap polish

### DIFF
--- a/moo-ds/src/css/components/_combo-box.css
+++ b/moo-ds/src/css/components/_combo-box.css
@@ -111,6 +111,9 @@
     ol {
         max-height: 20vh;
         overflow-y: auto;
+        /* Reserve the scrollbar track so the list doesn't reflow by a few
+           pixels as filtering crosses the max-height threshold. */
+        scrollbar-gutter: stable;
         border-radius: var(--border-radius, 0.375rem);
         border: var(--border-width, 1px) solid var(--border-colour);
         list-style: none;

--- a/moo-ds/src/css/components/_forms.css
+++ b/moo-ds/src/css/components/_forms.css
@@ -16,7 +16,7 @@
     transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
-.form-control:focus {
+.form-control:focus-visible {
     color: var(--body-colour);
     background-color: var(--body-bg);
     border-color: var(--primary);
@@ -101,7 +101,7 @@ textarea.form-control {
     transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
-.form-select:focus {
+.form-select:focus-visible {
     border-color: var(--primary);
     outline: 0;
     box-shadow: 0 0 0 0.25rem color-mix(in srgb, var(--primary) 25%, transparent);
@@ -159,49 +159,27 @@ option {
     }
 }
 
+/* Checkboxes and radios render natively and are tinted with accent-color, so
+   the platform draws the tick and dot. That removes the two SVG data URIs and
+   the custom box/border they were painted on, and means the controls follow
+   the OS conventions for pressed state and forced-colors mode for free.
+   The switch is not a native control, so it keeps appearance: none and owns
+   its box styling below. */
 .form-check-input {
-    --form-check-bg: var(--body-bg);
+    accent-color: var(--primary);
     flex-shrink: 0;
     width: 1.5rem;
     height: 1.5rem;
     margin-top: 0;
     padding: 0;
     vertical-align: top;
-    appearance: none;
-    background-color: var(--form-check-bg);
-    background-image: var(--form-check-bg-image);
-    background-repeat: no-repeat;
-    background-position: center;
-    background-size: contain;
-    border: var(--border-width, 1px) solid var(--border-colour, rgba(0, 0, 0, 0.25));
-    print-color-adjust: exact;
 }
 
-.form-check-input[type="checkbox"] {
-    border-radius: 0.25em;
-}
-
-.form-check-input[type="radio"] {
-    border-radius: 50%;
-}
-
-.form-check-input:focus {
-    border-color: hsl(from var(--primary) h calc(s * .37) 64%);
+/* Keyboard-only ring, matching the .btn convention in _buttons.css. A native
+   checkbox has no border to tint, so this is the ring alone. */
+.form-check-input:focus-visible {
     outline: 0;
     box-shadow: 0 0 0 0.25rem color-mix(in srgb, var(--primary) 25%, transparent);
-}
-
-.form-check-input:checked {
-    background-color: var(--primary);
-    border-color: var(--primary);
-}
-
-.form-check-input:checked[type="checkbox"] {
-    --form-check-bg-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='m6 10 3 3 6-6'/%3e%3c/svg%3e");
-}
-
-.form-check-input:checked[type="radio"] {
-    --form-check-bg-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='2' fill='%23fff'/%3e%3c/svg%3e");
 }
 
 .form-check-input:disabled {
@@ -227,20 +205,31 @@ option {
 .form-switch {
     padding-left: 0;
 
+    /* The switch is drawn by us rather than by the platform, so it opts out of
+       the native rendering the base .form-check-input now relies on and
+       restores the box styling that used to live there. */
     .form-check-input {
         --form-switch-thumb-light: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba%280, 0, 0, 0.55%29'/%3e%3c/svg%3e");
         --form-switch-thumb-dark: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba%28255, 255, 255, 0.55%29'/%3e%3c/svg%3e");
         --form-switch-bg: var(--form-switch-thumb-light);
+        appearance: none;
         width: 2.8em;
         height: 1.5em;
+        background-color: var(--body-bg);
         background-image: var(--form-switch-bg);
+        background-repeat: no-repeat;
+        background-size: contain;
         background-position: left center;
+        border: var(--border-width, 1px) solid var(--border-colour, rgba(0, 0, 0, 0.25));
         border-radius: 2em;
+        print-color-adjust: exact;
         transition: background-position 0.15s ease-in-out;
     }
 
     .form-check-input:checked {
         background-position: right center;
+        background-color: var(--primary);
+        border-color: var(--primary);
         --form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23fff'/%3e%3c/svg%3e");
     }
 }

--- a/moo-ds/src/css/components/_modal.css
+++ b/moo-ds/src/css/components/_modal.css
@@ -21,6 +21,9 @@
     height: 100%;
     overflow-x: hidden;
     overflow-y: auto;
+    /* Reserve the scrollbar track so a modal whose content grows past the
+       viewport doesn't shift horizontally when the scrollbar appears. */
+    scrollbar-gutter: stable;
     outline: 0;
 }
 

--- a/moo-ds/src/css/components/_nav.css
+++ b/moo-ds/src/css/components/_nav.css
@@ -27,7 +27,7 @@
 }
 
 .nav-link:hover,
-.nav-link:focus {
+.nav-link:focus-visible {
     color: var(--nav-link-hover-colour);
 }
 

--- a/moo-ds/src/css/components/_offcanvas.css
+++ b/moo-ds/src/css/components/_offcanvas.css
@@ -69,6 +69,9 @@
     flex-grow: 1;
     padding: var(--offcanvas-padding-y) var(--offcanvas-padding-x);
     overflow-y: auto;
+    /* Reserve the scrollbar track so the body doesn't reflow when content
+       grows past the panel height. */
+    scrollbar-gutter: stable;
 }
 
 .offcanvas-backdrop {

--- a/moo-ds/src/css/components/_pagination.css
+++ b/moo-ds/src/css/components/_pagination.css
@@ -49,7 +49,7 @@
     border-color: var(--pagination-hover-border-colour);
 }
 
-.page-link:focus {
+.page-link:focus-visible {
     z-index: 3;
     color: var(--pagination-focus-colour);
     background-color: var(--pagination-focus-bg);

--- a/moo-ds/src/css/components/_tooltip.css
+++ b/moo-ds/src/css/components/_tooltip.css
@@ -21,6 +21,9 @@
     padding: var(--tooltip-padding-y) var(--tooltip-padding-x);
     color: var(--tooltip-colour);
     text-align: center;
+    /* Centred text reads badly with a ragged last line, and a tooltip is
+       short enough that balancing costs nothing. */
+    text-wrap: balance;
     background-color: var(--tooltip-bg);
     border-radius: var(--tooltip-border-radius);
     opacity: var(--tooltip-opacity);

--- a/moo-ds/src/css/layout/_section.css
+++ b/moo-ds/src/css/layout/_section.css
@@ -19,6 +19,8 @@
     h1,h2,h3,h4,h5,h6 {
         padding: 0 0 1rem;
         margin: 0;
+        /* Even out ragged line breaks on wrapped section headings. */
+        text-wrap: balance;
     }
 
     .section-header a {


### PR DESCRIPTION
Sequencing step 2 of #657 — the cheap, low-risk sweep across components that lagged conventions the design system already uses elsewhere.

> **Stacked on #672.** Base is `feature/css-light-dark-consolidation` so the diff stays clean (both touch `_forms.css`). Merge #672 first and this will retarget to `main`.

## `:focus-visible` parity

Replaces `:focus` on `.form-control`, `.form-select`, `.form-check-input`, `.nav-link` and `.page-link`, matching the `.btn` convention already at `_buttons.css:44,302`.

Verified with **real** input events (CDP-driven click and Tab, not synthetic `dispatchEvent`):

| Element | Interaction | `:focus-visible` | ring |
|---|---|---|---|
| checkbox | real mouse click | `false` | none — correct |
| checkbox | real `Tab` | `true` | shown — correct |
| **text input** | real mouse click | `true` | **shown — correct** |

That last row is the one worth checking: text inputs *must* keep their ring on click, and they do, because browsers treat keyboard-editable elements as always focus-visible. So this is a pure improvement with no regression for typing.

## `accent-color` for checkbox and radio

`accent-color: var(--primary)` replaces the custom-painted control, deleting both SVG data URIs and the box they were painted on. The platform now supplies the tick, the pressed state and forced-colors handling.

**This is a real rendering change** — the controls are now native, so they follow OS conventions (unchecked in dark mode is a filled grey box rather than `--body-bg` with a border) and `border-radius` no longer applies. Screenshotted in both themes across off/on/indeterminate/disabled before committing.

**Bonus fix:** the indeterminate state had **no rule at all** previously, so an indeterminate checkbox rendered identically to unchecked. It now draws a proper dash.

The switch is not a native control, so it keeps `appearance: none` and now owns the box styling (background, border, `print-color-adjust`, primary checked fill) it used to inherit from the shared base rule.

## Cheap polish

- `scrollbar-gutter: stable` on the combobox list, modal and offcanvas body — stops those containers reflowing as content crosses the scroll threshold.
- `text-wrap: balance` on section headings and tooltip text (the tooltip is centre-aligned, where a ragged last line reads worst).

## One item deliberately not converted

#657 lists `_combo-box.css:106` for `:focus-visible`, but that rule is `input:focus { outline: none }` — a **suppression**, with the visible ring coming from the wrapper's `:focus-within`. Narrowing it to `:focus-visible` would *leave* a UA outline on mouse focus rather than remove one, so it stays as `:focus`.

## Verification

- `npm run build -w @andrewmclachlan/moo-ds` — clean
- `npm run test:run` — 1699/1699 pass (unchanged from baseline)
- No dangling references to the removed `--form-check-bg` / `--form-check-bg-image` tokens

Refs #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)