### PR TITLE
refactor(moo-ds): derive colours from --primary instead of parallel rgb triplets

### DIFF
--- a/moo-ds/src/css/_variables.css
+++ b/moo-ds/src/css/_variables.css
@@ -1,3 +1,29 @@
+/* Registered colour tokens. Registering with syntax: '<color>' adds validation
+   and -- the actual reason to bother -- makes the token animatable, because an
+   unregistered custom property cannot be interpolated.
+
+   Only tokens holding a plain colour may be registered. A registered property
+   is computed at the element that declares it; an unregistered one is
+   substituted lazily where it is used. Every light-dark() token below is
+   declared on :root (color-scheme: light dark) but consumed inside
+   .light/.dark/[data-theme] subtrees, which is what makes theme forcing work.
+   Registering one freezes it to whatever the OS preference resolved to at
+   :root, and forced themes silently stop applying -- confirmed in Chromium,
+   where a registered light-dark() token kept its dark value even inside
+   color-scheme: light. So the light-dark() tokens are deliberately left
+   unregistered; do not "finish the job" by adding them here. */
+@property --primary {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #8b0000;
+}
+
+@property --primary-dark {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #6f0000;
+}
+
 :root {
   --font-sans-serif: 'Inter', 'Franklin Gothic', Helvetica, 'Helvetica Neue', system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
   --secondary-fonts: 'Open Sans Condensed', 'Franklin Gothic', Helvetica, 'Helvetica Neue', nsystem-ui, -apple-system, "Segoe UI", Roboto Arial, sans-serif;
@@ -5,7 +31,6 @@
   --page-header-background: #111;
   --page-header-text: #F6F6F6;
 
-  --primary-rgb: 139, 0, 0;
   --primary-dark: #6f0000;
 
   --input-border: #666;
@@ -47,7 +72,10 @@
   --light-section-bg: rgb(251, 248, 244);
   --dark-section-bg: rgb(21, 13, 12);
 
-  --btn-focus-shadow-rgb: 156, 38, 38;
+  /* Focus ring base: --primary lightened. Derived rather than stored as a
+     separate literal so a theme that changes --primary gets a matching ring
+     without having to restate it. Reproduces the previous 156,38,38. */
+  --focus-ring-colour: color-mix(in srgb, var(--primary) 85%, #fff);
 
   --border-width: 1px;
   --border-radius: 0.375rem;
@@ -75,8 +103,12 @@
 
   --hover: light-dark(#e6e6e6, #6e6e6e);
 
-  --link-colour: light-dark(#8b0000, rgb(185.4, 102, 102));
-  --link-hover-colour: light-dark(rgb(111.2, 0, 0), rgb(199.32, 132.6, 132.6));
+  /* Link colours are all --primary derivatives. They were previously baked as
+     fractional rgb() literals (rgb(185.4, 102, 102) and friends) produced by a
+     preprocessor, which meant a theme changing --primary left them stale.
+     These mixes reproduce those literals exactly. */
+  --link-colour: light-dark(var(--primary), color-mix(in srgb, var(--primary) 60%, #fff));
+  --link-hover-colour: light-dark(color-mix(in srgb, var(--primary) 80%, #000), color-mix(in srgb, var(--primary) 48%, #fff));
 
   --disabled-bg: light-dark(#e9ecef, #495057);
   --input-group-text-bg: light-dark(#e9ecef, #495057);
@@ -125,7 +157,6 @@ body {
 .dark.blue {
 
   --primary: #2f5fad;
-  --primary-rgb: 47, 95, 173;
   --primary-dark: #2f4c84;
 
   --body-bg: rgb(8, 9, 12);
@@ -135,8 +166,18 @@ body {
   --body-colour-dim: rgba(204, 208, 211, .65);
   --border-colour: rgb(45, 49, 52);
 
-  --link-colour: rgb(102, 102, 185.4);
-  --link-hover-colour: rgb(132.6, 132.6, 199.32);
+  /* These have to be restated, not inherited. A var() inside a custom property
+     is substituted at the element that *declares* it, so the :root copies of
+     these tokens already resolved var(--primary) to the default red and pass
+     it down as a fixed value -- overriding --primary here cannot reach back
+     into them. Restating them keeps the derivation (rather than the previous
+     baked literals, which were the red values with the channels reordered:
+     rgb(185.4, 102, 102) -> rgb(102, 102, 185.4)) so they now actually track
+     this theme's --primary. */
+  --focus-ring-colour: color-mix(in srgb, var(--primary) 85%, #fff);
+  --link-colour: light-dark(var(--primary), color-mix(in srgb, var(--primary) 60%, #fff));
+  --link-hover-colour: light-dark(color-mix(in srgb, var(--primary) 80%, #000), color-mix(in srgb, var(--primary) 48%, #fff));
+
   --base-bg: rgb(12, 13, 17);
   --header-bg: rgb(12, 13, 17);
   --section-bg: rgb(12, 13, 17);
@@ -144,6 +185,5 @@ body {
   --footer-bg: rgb(12, 13, 17);
   --breadcrumb-bg: rgb(12, 13, 17);
   --table-striped-bg: rgba(12, 13, 17, 0.75);
-  --btn-focus-shadow-rgb: 38, 38, 156;
 
 }

--- a/moo-ds/src/css/components/_buttons.css
+++ b/moo-ds/src/css/components/_buttons.css
@@ -14,7 +14,8 @@
     --btn-hover-border-colour: transparent;
     --btn-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15), 0 1px 1px rgba(0, 0, 0, 0.075);
     --btn-disabled-opacity: 0.65;
-    --btn-focus-box-shadow: 0 0 0 0.25rem rgba(var(--btn-focus-shadow-rgb), 0.5);
+    --btn-focus-ring-colour: var(--focus-ring-colour);
+    --btn-focus-box-shadow: 0 0 0 0.25rem color-mix(in srgb, var(--btn-focus-ring-colour) 50%, transparent);
 
     display: inline-block;
     padding: var(--btn-padding-y) var(--btn-padding-x);
@@ -73,7 +74,6 @@
     --btn-hover-colour: #fff;
     --btn-hover-bg: var(--primary-dark);
     --btn-hover-border-colour: var(--primary-dark);
-    --btn-focus-shadow-rgb: var(--btn-focus-shadow-rgb, 156, 38, 38);
     --btn-active-colour: #fff;
     --btn-active-bg: var(--primary-dark);
     --btn-active-border-colour: var(--primary-dark);
@@ -90,7 +90,6 @@
     --btn-hover-colour: #fff;
     --btn-hover-bg: var(--primary);
     --btn-hover-border-colour: var(--primary);
-    --btn-focus-shadow-rgb: var(--btn-focus-shadow-rgb, 156, 38, 38);
     --btn-active-colour: #fff;
     --btn-active-bg: var(--primary-dark);
     --btn-active-border-colour: var(--primary-dark);
@@ -116,7 +115,7 @@
     --btn-disabled-bg: transparent;
     --btn-disabled-border-colour: transparent;
     --btn-box-shadow: 0 0 0 #000;
-    --btn-focus-shadow-rgb: 49, 132, 253;
+    --btn-focus-ring-colour: var(--link-colour);
     text-decoration: underline;
 }
 


### PR DESCRIPTION
Part of #657 Tier 2 — retiring the duplicated colour storage so themes only have to state `--primary`.

> **Stacked on #673** (which is stacked on #672). Merge in order: #672 → #673 → this.

## What was duplicated

Colours were stored twice — once as a hex value and again as a bare rgb triplet for `rgba()` — or baked as preprocessor-generated fractional literals like `rgb(185.4, 102, 102)` that went stale whenever `--primary` changed.

Every one of those literals turned out to be an **exact** `--primary` derivative:

| Token | Derivation | Baked literal |
|---|---|---|
| link (light) | `--primary` | `#8b0000` |
| link hover (light) | `mix(--primary 80%, #000)` | `rgb(111.2, 0, 0)` |
| link (dark) | `mix(--primary 60%, #fff)` | `rgb(185.4, 102, 102)` |
| link hover (dark) | `mix(--primary 48%, #fff)` | `rgb(199.32, 132.6, 132.6)` |
| focus ring | `mix(--primary 85%, #fff)` | `156, 38, 38` |

## Dead code and no-ops removed

- **`--primary-rgb`** — declared in two places, **never referenced anywhere**. Deleted.
- **`--btn-focus-shadow-rgb: var(--btn-focus-shadow-rgb, 156, 38, 38)`** (×2) — self-referential, which is invalid at computed-value time. These were **already no-ops**.
- **`.btn-link`'s `49, 132, 253`** — a hardcoded Bootstrap blue in a palette with no blue. Now follows `--link-colour`, which is the colour that button's own text already uses.

## Verified against the previous stylesheet

Built the old and new stylesheets and compared computed colours in-browser:

| Theme | link | link hover |
|---|---|---|
| default light | **SAME** `rgb(139, 0, 0)` | **SAME** `rgb(111, 0, 0)` |
| default dark | **SAME** `rgb(185, 102, 102)` | **SAME** `rgb(199, 133, 133)` |
| blue | `rgb(102, 102, 185)` → `rgb(130, 159, 206)` | `rgb(133, 133, 199)` → `rgb(155, 178, 216)` |

Default themes are identical. The focus ring likewise matches to within 0.4/255 (the old triplet had rounded 156.4 down to 156).

**The blue theme changes on purpose.** Its literals were the *red* theme's values with the channels reordered (`rgb(185.4, 102, 102)` → `rgb(102, 102, 185.4)`) and bore no relation to its own `#2f5fad` primary. Links and ring are now hue-matched to it.

## A subtlety worth flagging for review

I initially deleted the `.dark.blue` link/ring overrides as redundant — and that **silently gave the blue theme red links.** A `var()` inside a custom property is substituted at the element that *declares* it, so the `:root` copies have already resolved `var(--primary)` to the default red before `.dark.blue` on `<body>` can change it. Caught it in the before/after comparison.

They are now restated in `.dark.blue` as the same derivations (so they track that theme's primary) with a comment explaining why inheritance can't do the job.

## `@property`: applied narrowly, and here's why

#657 recommends registering the colour tokens for validation and animatability. **Registering the `light-dark()` tokens would break theming**, so only `--primary` and `--primary-dark` (plain colours) are registered.

A registered property is computed at its *declaring* element. The 37 `light-dark()` tokens are declared on `:root` (`color-scheme: light dark`) but consumed inside `.light`/`.dark` subtrees — which is exactly what makes theme forcing work. Registering one freezes it to whatever the OS preference resolved to at `:root`.

Confirmed in Chromium with a registered/unregistered pair:

```
unregistered:  forced-dark -> BLUE(dark)   forced-light -> RED(light)    correct
registered:    forced-dark -> BLUE(dark)   forced-light -> BLUE(dark)    BROKEN
```

`_variables.css` now carries a comment recording this so nobody "finishes the job" later.

## Deliberately not in this PR

The `color-mix(in oklab …)` shade-ramp change from the same Tier 2 bullet is a genuine **visual** change to every button hover/active shade, unlike everything above which reproduces exactly. Split out so this PR keeps "no change to the default themes" as a reviewable property.

## Verification

- `npm run build -w @andrewmclachlan/moo-ds` — clean
- `npm run test:run` — 1699/1699 pass
- No `--*-rgb` triplets remain anywhere in the repo

Refs #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)