### PR TITLE
refactor(moo-ds): anchor-position the combobox list and auto-size textareas

### DIFF
--- a/moo-ds/src/components/OverlayTrigger.tsx
+++ b/moo-ds/src/components/OverlayTrigger.tsx
@@ -10,20 +10,6 @@ export interface OverlayTriggerProps {
     children: React.ReactElement;
 }
 
-const placementToPositionArea: Record<string, string> = {
-    top: "top",
-    bottom: "bottom",
-    left: "left",
-    right: "right",
-};
-
-const placementToFlip: Record<string, string> = {
-    top: "flip-block",
-    bottom: "flip-block",
-    left: "flip-inline",
-    right: "flip-inline",
-};
-
 export const OverlayTrigger: React.FC<OverlayTriggerProps> = ({
     trigger = "click",
     placement = "bottom",
@@ -45,16 +31,18 @@ export const OverlayTrigger: React.FC<OverlayTriggerProps> = ({
         triggerRef.current?.style.setProperty("anchor-name", anchorName);
     }, [anchorName]);
 
+    // position-anchor has to be set here because the anchor name is generated
+    // per trigger instance. position-area and the flip fallbacks are driven by
+    // the .overlay-<placement> class instead, so the placement mapping lives in
+    // _overlay.css rather than in inline styles.
     useLayoutEffect(() => {
         if (show && overlayRef.current) {
             overlayRef.current.style.setProperty("position-anchor", anchorName);
-            overlayRef.current.style.setProperty("position-area", placementToPositionArea[placement]);
-            overlayRef.current.style.setProperty("position-try-fallbacks", placementToFlip[placement]);
             if (containerPadding > 0) {
                 overlayRef.current.style.setProperty("--overlay-padding", `${containerPadding}px`);
             }
         }
-    }, [show, anchorName, placement, containerPadding]);
+    }, [show, anchorName, containerPadding]);
 
     useEffect(() => {
         if (!show || !rootClose) return () => {};
@@ -102,7 +90,7 @@ export const OverlayTrigger: React.FC<OverlayTriggerProps> = ({
             {show && createPortal(
                 <div
                     ref={overlayRef}
-                    className="overlay-portal"
+                    className={`overlay-portal overlay-${placement}`}
                 >
                     {typeof overlay === "function" ? overlay(() => setShow(false)) : overlay}
                 </div>,

--- a/moo-ds/src/components/__tests__/OverlayTrigger.test.tsx
+++ b/moo-ds/src/components/__tests__/OverlayTrigger.test.tsx
@@ -118,6 +118,42 @@ describe('OverlayTrigger', () => {
     });
   });
 
+  // The placement drives position-area and position-try-fallbacks through the
+  // overlay-<placement> class in _overlay.css rather than through inline
+  // styles, so the class landing on the portal is the whole contract.
+  describe('placement class', () => {
+    it.each([
+      ['top', 'overlay-top'],
+      ['bottom', 'overlay-bottom'],
+      ['left', 'overlay-left'],
+      ['right', 'overlay-right'],
+    ] as const)('applies %s placement as .%s', (placement, expected) => {
+      render(
+        <OverlayTrigger trigger="click" placement={placement} overlay={overlay}>
+          <button>Toggle</button>
+        </OverlayTrigger>
+      );
+
+      fireEvent.click(screen.getByText('Toggle'));
+
+      const portal = screen.getByText('Overlay content').parentElement;
+      expect(portal).toHaveClass('overlay-portal');
+      expect(portal).toHaveClass(expected);
+    });
+
+    it('defaults to bottom placement', () => {
+      render(
+        <OverlayTrigger trigger="click" overlay={overlay}>
+          <button>Toggle</button>
+        </OverlayTrigger>
+      );
+
+      fireEvent.click(screen.getByText('Toggle'));
+
+      expect(screen.getByText('Overlay content').parentElement).toHaveClass('overlay-bottom');
+    });
+  });
+
   it('has displayName', () => {
     expect(OverlayTrigger.displayName).toBe('OverlayTrigger');
   });

--- a/moo-ds/src/css/components/_combo-box.css
+++ b/moo-ds/src/css/components/_combo-box.css
@@ -5,6 +5,16 @@
         position: relative;
         border-radius: var(--border-radius, 0.375rem);
         border: var(--border-width, 1px) solid var(--border-colour);
+        /* Anchor for the dropdown below. Set on the control itself so the list
+           can leave the flow entirely -- see the note on `ol`.
+
+           One shared name is safe even with several combo-boxes on a page: each
+           list is a descendant of its own control, so the nearest preceding
+           element carrying the name is always that control. Verified with two
+           controls on one page -- each list anchored to its own. A unique name
+           per instance (the approach OverlayTrigger has to take, since its
+           overlay is portalled away from the trigger) is not needed here. */
+        anchor-name: --combo-box;
     }
 
     :scope:focus-within {
@@ -108,6 +118,14 @@
         }
     }
 
+    /* Anchor positioned rather than position: absolute inside the control.
+       Absolute positioning kept the list inside the control's containing block,
+       so any ancestor with overflow: hidden clipped it -- dashboard widgets set
+       exactly that. position: fixed takes it out of the flow, position-anchor
+       keeps it pinned to the control, anchor-size() matches the control's width
+       (what width: 100% used to do), and flip-block moves it above the control
+       when there is no room below instead of running off-screen.
+       Follows the pattern already established in _tooltip.css. */
     ol {
         max-height: 20vh;
         overflow-y: auto;
@@ -117,9 +135,12 @@
         padding: 10px 0;
         margin: 3px 0 0;
         background-color: var(--body-bg);
-        position: absolute;
+        position: fixed;
+        position-anchor: --combo-box;
+        position-area: block-end;
+        width: anchor-size(width);
+        position-try-fallbacks: flip-block;
         z-index: 100;
-        width: 100%;
         border-radius: 5px;
 
         li {

--- a/moo-ds/src/css/components/_combo-box.css
+++ b/moo-ds/src/css/components/_combo-box.css
@@ -141,7 +141,6 @@
         width: anchor-size(width);
         position-try-fallbacks: flip-block;
         z-index: 100;
-        border-radius: 5px;
 
         li {
             padding: 10px 10px;

--- a/moo-ds/src/css/components/_combo-box.css
+++ b/moo-ds/src/css/components/_combo-box.css
@@ -8,13 +8,16 @@
         /* Anchor for the dropdown below. Set on the control itself so the list
            can leave the flow entirely -- see the note on `ol`.
 
-           One shared name is safe even with several combo-boxes on a page: each
-           list is a descendant of its own control, so the nearest preceding
-           element carrying the name is always that control. Verified with two
-           controls on one page -- each list anchored to its own. A unique name
-           per instance (the approach OverlayTrigger has to take, since its
-           overlay is portalled away from the trigger) is not needed here. */
+           anchor-scope confines the name to this control's own subtree. Without
+           it every combo-box on the page publishes the same name, and a list
+           binds to the last one in tree order rather than the control it sits
+           inside -- so an open dropdown rendered under whichever combo-box came
+           last. anchor-scope is from the same Safari 26 release as the rest of
+           anchor positioning, so it costs no support relative to the feature it
+           is fixing, and it keeps the name shared rather than needing one
+           generated per instance the way OverlayTrigger does. */
         anchor-name: --combo-box;
+        anchor-scope: --combo-box;
     }
 
     :scope:focus-within {

--- a/moo-ds/src/css/components/_forms.css
+++ b/moo-ds/src/css/components/_forms.css
@@ -73,6 +73,16 @@ textarea.form-control {
     min-height: calc(1.5em + 0.75rem + calc(var(--border-width, 1px) * 2));
 }
 
+/* Auto-grow to fit content, so a textarea does not need a scrollbar or a JS
+   autosize handler. Scoped to textareas with no `rows`: an author who set rows
+   asked for a specific height, and field-sizing: content would override it and
+   collapse the control to one line. The max-block-size stops a long value
+   growing without limit; past that it scrolls as before. */
+textarea.form-control:not([rows]) {
+    field-sizing: content;
+    max-block-size: 40vh;
+}
+
 /* Form select */
 .form-select {
     --form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3e%3cpath fill=%27none%27 stroke=%27%23343a40%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27 stroke-width=%272%27 d=%27m2 5 6 6 6-6%27/%3e%3c/svg%3e");

--- a/moo-ds/src/css/components/_overlay.css
+++ b/moo-ds/src/css/components/_overlay.css
@@ -5,3 +5,29 @@
     z-index: 1070;
     margin: var(--overlay-padding, 0);
 }
+
+/* Placement lives here rather than in OverlayTrigger, which previously wrote
+   position-area and position-try-fallbacks as inline styles from two JS lookup
+   tables. Only position-anchor still has to be set from JS, because the anchor
+   name is generated per trigger instance. Block placements flip block-ward and
+   inline placements flip inline-ward, so a placement that would overflow the
+   viewport lands on the opposite side rather than off-screen. */
+.overlay-portal.overlay-top {
+    position-area: top;
+    position-try-fallbacks: flip-block;
+}
+
+.overlay-portal.overlay-bottom {
+    position-area: bottom;
+    position-try-fallbacks: flip-block;
+}
+
+.overlay-portal.overlay-left {
+    position-area: left;
+    position-try-fallbacks: flip-inline;
+}
+
+.overlay-portal.overlay-right {
+    position-area: right;
+    position-try-fallbacks: flip-inline;
+}


### PR DESCRIPTION
Part of #657 Tier 2. **Branched from `main`.**

## Combobox dropdown: fixes a real clipping bug

The list was `position: absolute` inside the control, so it stayed in the control's containing block — **any ancestor with `overflow: hidden` clipped it, and dashboard widgets set exactly that.**

Now `position: fixed` + anchored to the control, following the pattern `_tooltip.css` already established:

| behaviour | result |
|---|---|
| inside `overflow: hidden` | list bottom **256px** vs clip edge **147px** — renders past it instead of being cut off |
| width | matches the control exactly (`anchor-size(width)` replaces `width: 100%`) |
| near viewport bottom | flips above the control and stays on screen |

## Correction: the shared anchor name needed scoping

An earlier revision of this PR claimed a single shared `anchor-name: --combo-box` was safe with several controls on a page. **That was wrong, and it shipped a visible bug** — on demoo's Form page, Input 3's open dropdown rendered underneath Input 5.

`position-anchor` binds to the **last** element in tree order publishing that name, not the nearest enclosing one. So every open list bound to whichever combo-box came last.

The claim was wrong because the test was unrepresentative: it wrapped each control in a `position: fixed` div and had *both* lists open. Neither matches the real markup — `ComboBoxList` returns `null` when closed, so normally exactly one `<ol>` exists, in normal flow. Re-tested against that shape:

```
before:  list top 220  (cb5's bottom 217)  -- bound to the last control
after:   list top  78  (cb3's bottom  75)  -- bound to its own
```

Fixed with `anchor-scope: --combo-box`, which confines the name to each control's own subtree. It shipped in **Safari 26 / iOS Safari 26** alongside the rest of anchor positioning, so it costs nothing in support relative to the feature it fixes, and it avoids needing a name generated per instance the way `OverlayTrigger` does.

With the fix, two lists open simultaneously each bind to their own control, and the list's width tracks its own control.

## Textareas auto-size

`field-sizing: content` on `textarea.form-control` — grows **43px → 127px** for five lines instead of scrolling.

Scoped to `:not([rows])`: an author who set `rows` asked for a specific height, and `field-sizing: content` would override it and collapse the control to one line. Confirmed `rows="4"` still computes `field-sizing: fixed`. A `max-block-size: 40vh` stops unbounded growth.

## Placement moves out of inline styles

`OverlayTrigger` was writing `position-area` and `position-try-fallbacks` as **inline styles** from two JS lookup tables. Both are a static function of the `placement` prop, so they become `.overlay-<placement>` classes in `_overlay.css` — which is also what CLAUDE.md's no-inline-styles rule asks for. `position-anchor` stays in JS because the anchor name is generated per instance. Covered by 5 tests, mutation-checked.

## Two things the issue expects that aren't there

- **"removes JS resize logic"** for the combobox input — there is none. The only measurement code is `ComboBoxPills`' overflow calculation for the "+N more" chip.
- **"`_popover.css` positions manually"** — it doesn't. Popovers already go through `OverlayTrigger`'s anchor positioning.

`field-sizing` is also deliberately **not** applied to the combobox input: it shares a flex row with the pills, and making it content-sized would fight that overflow measurement.

## Verification

- `npm run build -w @andrewmclachlan/moo-ds` — clean
- `npm run test:run` — 1719/1719 pass
- Anchor binding re-tested against the real markup shape, not a synthetic one

Refs #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)