### PR TITLE
feat(moo-ds): render tooltips and popovers in the top layer

### DIFF
--- a/demoo/src/App.css
+++ b/demoo/src/App.css
@@ -142,3 +142,20 @@
 .skeleton-media { display: flex; gap: 1rem; align-items: center; max-width: 420px; }
 .skeleton-media .fill { flex: 1; }
 .avatar-lg { width: 64px; height: 64px; border-radius: 50%; }
+
+/* Deliberately obstructive panel for the Overlays "above everything else"
+   sample: the largest z-index a page can use, which a top-layer overlay still
+   paints over. */
+.stacking-rival {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483647;
+  background: rgba(0, 90, 40, 0.55);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: monospace;
+  font-size: 1.25rem;
+  pointer-events: none;
+}

--- a/demoo/src/routes/overlays/Overlays.tsx
+++ b/demoo/src/routes/overlays/Overlays.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 export const Overlays = () => {
 
     const [showModal, setShowModal] = useState(false);
+    const [showRival, setShowRival] = useState(false);
 
     return (
         <Page title="Overlays" breadcrumbs={[{ route: "/overlays", text: "Overlays" }]}>
@@ -151,6 +152,30 @@ export const Overlays = () => {
                         <Button variant="outline-secondary">Body Only</Button>
                     </OverlayTrigger>
                 </div>
+            </Section>
+
+            <Section title="Stacking" header="Above everything else" headerSize={4}>
+                <p>
+                    Tooltips and popovers render in the browser&rsquo;s top layer, so nothing on the
+                    page can cover them. Show the panel below &mdash; it sits at the highest
+                    <code> z-index</code> a page can use &mdash; then hover the tooltip or open the
+                    popover. Both stay on top; a plain <code>z-index</code> of 1080 would lose to it.
+                </p>
+                <div className="demo-row">
+                    <Button variant="outline-primary" onClick={() => setShowRival(!showRival)}>
+                        {showRival ? "Hide panel" : "Show panel"}
+                    </Button>
+                    <span>Hover me <Tooltip id="stacking">This stays above the panel.</Tooltip></span>
+                    <OverlayTrigger
+                        trigger="click"
+                        placement="bottom"
+                        rootClose
+                        overlay={<Popover id="stacking-popover"><Popover.Body>So does this.</Popover.Body></Popover>}
+                    >
+                        <Button variant="outline-secondary">Open popover</Button>
+                    </OverlayTrigger>
+                </div>
+                {showRival && <div className="stacking-rival">z-index: 2147483647</div>}
             </Section>
 
         </Page>

--- a/moo-ds/src/components/OverlayTrigger.tsx
+++ b/moo-ds/src/components/OverlayTrigger.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState, useEffect, useId, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
+import { topLayerProps } from "../utils/topLayer";
 
 export interface OverlayTriggerProps {
     trigger?: "click" | "hover" | "focus" | ("click" | "hover" | "focus")[];
@@ -37,6 +38,12 @@ export const OverlayTrigger: React.FC<OverlayTriggerProps> = ({
     // _overlay.css rather than in inline styles.
     useLayoutEffect(() => {
         if (show && overlayRef.current) {
+            // Promote into the top layer -- see the note in Tooltip.tsx. The
+            // z-index: 1070 this replaces cannot win against a top-layer
+            // dialog. Optional call so jsdom, which has no popover API, keeps
+            // rendering the overlay in place.
+            overlayRef.current.showPopover?.();
+
             overlayRef.current.style.setProperty("position-anchor", anchorName);
             if (containerPadding > 0) {
                 overlayRef.current.style.setProperty("--overlay-padding", `${containerPadding}px`);
@@ -91,6 +98,7 @@ export const OverlayTrigger: React.FC<OverlayTriggerProps> = ({
                 <div
                     ref={overlayRef}
                     className={`overlay-portal overlay-${placement}`}
+                    {...topLayerProps()}
                 >
                     {typeof overlay === "function" ? overlay(() => setShow(false)) : overlay}
                 </div>,

--- a/moo-ds/src/components/OverlayTrigger.tsx
+++ b/moo-ds/src/components/OverlayTrigger.tsx
@@ -39,9 +39,10 @@ export const OverlayTrigger: React.FC<OverlayTriggerProps> = ({
     useLayoutEffect(() => {
         if (show && overlayRef.current) {
             // Promote into the top layer -- see the note in Tooltip.tsx. The
-            // z-index: 1070 this replaces cannot win against a top-layer
-            // dialog. Optional call so jsdom, which has no popover API, keeps
-            // rendering the overlay in place.
+            // z-index: 1070 this replaces loses to any higher z-index on the
+            // page, and to a top-layer dialog outright. Optional call so
+            // jsdom, which has no popover API, keeps rendering the overlay in
+            // place.
             overlayRef.current.showPopover?.();
 
             overlayRef.current.style.setProperty("position-anchor", anchorName);

--- a/moo-ds/src/components/OverlayTrigger.tsx
+++ b/moo-ds/src/components/OverlayTrigger.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect, useId, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
-import { topLayerProps } from "../utils/topLayer";
+import { showInTopLayer, topLayerProps } from "../utils/topLayer";
 
 export interface OverlayTriggerProps {
     trigger?: "click" | "hover" | "focus" | ("click" | "hover" | "focus")[];
@@ -40,10 +40,10 @@ export const OverlayTrigger: React.FC<OverlayTriggerProps> = ({
         if (show && overlayRef.current) {
             // Promote into the top layer -- see the note in Tooltip.tsx. The
             // z-index: 1070 this replaces loses to any higher z-index on the
-            // page, and to a top-layer dialog outright. Optional call so
-            // jsdom, which has no popover API, keeps rendering the overlay in
+            // page, and to a top-layer dialog outright. Guarded, so jsdom --
+            // which has no popover API -- keeps rendering the overlay in
             // place.
-            overlayRef.current.showPopover?.();
+            showInTopLayer(overlayRef.current);
 
             overlayRef.current.style.setProperty("position-anchor", anchorName);
             if (containerPadding > 0) {

--- a/moo-ds/src/components/Tooltip.tsx
+++ b/moo-ds/src/components/Tooltip.tsx
@@ -19,11 +19,11 @@ export const Tooltip: React.FC<PropsWithChildren<{ id: string }>> = ({ id, child
     useLayoutEffect(() => {
         if (show && portalRef.current && triggerRef.current) {
             // Promote into the top layer. The tooltip previously relied on
-            // z-index: 1080 to sit above everything, which only works while
-            // nothing else establishes a competing stacking context -- and
-            // would stop working entirely against a top-layer dialog, which
-            // paints above any z-index. Optional call so environments without
-            // the popover API (jsdom) just render it in place as before.
+            // z-index: 1080, which loses to anything on the page carrying a
+            // higher one -- a third-party widget, an app-level overlay --
+            // and loses outright to a top-layer dialog, which paints above
+            // any z-index at all. Optional call so environments without the
+            // popover API (jsdom) just render it in place as before.
             portalRef.current.showPopover?.();
 
             portalRef.current.style.setProperty("position-anchor", anchorName);

--- a/moo-ds/src/components/Tooltip.tsx
+++ b/moo-ds/src/components/Tooltip.tsx
@@ -1,7 +1,7 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { type PropsWithChildren, useId, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { topLayerProps } from "../utils/topLayer";
+import { showInTopLayer, topLayerProps } from "../utils/topLayer";
 
 export const Tooltip: React.FC<PropsWithChildren<{ id: string }>> = ({ id, children }) => {
     const uniqueId = useId();
@@ -22,9 +22,9 @@ export const Tooltip: React.FC<PropsWithChildren<{ id: string }>> = ({ id, child
             // z-index: 1080, which loses to anything on the page carrying a
             // higher one -- a third-party widget, an app-level overlay --
             // and loses outright to a top-layer dialog, which paints above
-            // any z-index at all. Optional call so environments without the
-            // popover API (jsdom) just render it in place as before.
-            portalRef.current.showPopover?.();
+            // any z-index at all. Guarded, so an environment without the
+            // popover API (jsdom) just renders it in place as before.
+            showInTopLayer(portalRef.current);
 
             portalRef.current.style.setProperty("position-anchor", anchorName);
             const triggerRect = triggerRef.current.getBoundingClientRect();

--- a/moo-ds/src/components/Tooltip.tsx
+++ b/moo-ds/src/components/Tooltip.tsx
@@ -1,6 +1,7 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { type PropsWithChildren, useId, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { topLayerProps } from "../utils/topLayer";
 
 export const Tooltip: React.FC<PropsWithChildren<{ id: string }>> = ({ id, children }) => {
     const uniqueId = useId();
@@ -17,6 +18,14 @@ export const Tooltip: React.FC<PropsWithChildren<{ id: string }>> = ({ id, child
 
     useLayoutEffect(() => {
         if (show && portalRef.current && triggerRef.current) {
+            // Promote into the top layer. The tooltip previously relied on
+            // z-index: 1080 to sit above everything, which only works while
+            // nothing else establishes a competing stacking context -- and
+            // would stop working entirely against a top-layer dialog, which
+            // paints above any z-index. Optional call so environments without
+            // the popover API (jsdom) just render it in place as before.
+            portalRef.current.showPopover?.();
+
             portalRef.current.style.setProperty("position-anchor", anchorName);
             const triggerRect = triggerRef.current.getBoundingClientRect();
             const portalRect = portalRef.current.getBoundingClientRect();
@@ -46,6 +55,7 @@ export const Tooltip: React.FC<PropsWithChildren<{ id: string }>> = ({ id, child
                     className="tooltip-content tooltip-portal"
                     id={tooltipId}
                     role="tooltip"
+                    {...topLayerProps()}
                 >
                     {children}
                 </span>,

--- a/moo-ds/src/css/components/_combo-box.css
+++ b/moo-ds/src/css/components/_combo-box.css
@@ -143,6 +143,19 @@
         z-index: 100;
         border-radius: 5px;
 
+        /* Fade in on open. Scale rather than a slide because flip-block can put
+           the list above the control, where a downward slide would read wrong.
+
+           Entry only: ComboBoxList returns null when closed, so React removes
+           the node and there is nothing left to transition on the way out. */
+        transition: opacity 0.12s ease-out, scale 0.12s ease-out;
+        transform-origin: top center;
+
+        @starting-style {
+            opacity: 0;
+            scale: 0.98;
+        }
+
         li {
             padding: 10px 10px;
             cursor: pointer;

--- a/moo-ds/src/css/components/_combo-box.css
+++ b/moo-ds/src/css/components/_combo-box.css
@@ -148,11 +148,29 @@
            Entry only: ComboBoxList returns null when closed, so React removes
            the node and there is nothing left to transition on the way out. */
         transition: opacity 0.12s ease-out, scale 0.12s ease-out;
+        /* Grow away from the control: the edge nearest it stays put. Below the
+           control that is the top edge; flipped above, it is the bottom one,
+           so the origin follows the fallback the same way the tooltip's slide
+           direction does in _tooltip.css. */
         transform-origin: top center;
+
+        @container anchored(fallback: flip-block) {
+            transform-origin: bottom center;
+        }
 
         @starting-style {
             opacity: 0;
             scale: 0.98;
+        }
+
+        /* Drop the scale, keep the fade, as the tooltip and overlay do. */
+        @media (prefers-reduced-motion: reduce) {
+            transition: opacity 0.12s ease-out;
+
+            @starting-style {
+                opacity: 0;
+                scale: none;
+            }
         }
 
         li {

--- a/moo-ds/src/css/components/_overlay.css
+++ b/moo-ds/src/css/components/_overlay.css
@@ -1,9 +1,21 @@
 /* Overlay portal styles (CSS anchor positioned) */
 
+/* Promoted into the top layer with popover="manual", so the overlay cannot be
+   trapped under a stacking context or painted beneath a top-layer dialog. The
+   [popover] UA styles are undone here -- inset: 0 with margin: auto centres the
+   element and fights position-area, and the default border, padding and
+   Canvas background would paint a box behind the popover's own content.
+   z-index stays as the fallback for anything without the popover API. */
 .overlay-portal {
     position: fixed;
     z-index: 1070;
     margin: var(--overlay-padding, 0);
+    inset: auto;
+    border: 0;
+    padding: 0;
+    overflow: visible;
+    background: none;
+    color: inherit;
 
     /* Fade and settle in on appear, with @starting-style supplying the
        pre-insertion value. Scale rather than a directional slide, because the

--- a/moo-ds/src/css/components/_overlay.css
+++ b/moo-ds/src/css/components/_overlay.css
@@ -20,9 +20,11 @@
     }
 }
 
+/* Drop the scale, keep the fade: a cross-fade is not motion, and removing the
+   transition outright would make the overlay snap in. */
 @media (prefers-reduced-motion: reduce) {
     .overlay-portal {
-        transition: none;
+        transition: opacity 0.15s ease-out;
 
         @starting-style {
             opacity: 0;

--- a/moo-ds/src/css/components/_overlay.css
+++ b/moo-ds/src/css/components/_overlay.css
@@ -4,6 +4,31 @@
     position: fixed;
     z-index: 1070;
     margin: var(--overlay-padding, 0);
+
+    /* Fade and settle in on appear, with @starting-style supplying the
+       pre-insertion value. Scale rather than a directional slide, because the
+       overlay can be placed on any of four sides and can flip to the opposite
+       one -- a translate would run the wrong way half the time.
+
+       Entry only: OverlayTrigger renders the portal as `{show && ...}`, so the
+       node is gone before an exit transition could run. */
+    transition: opacity 0.15s ease-out, scale 0.15s ease-out;
+
+    @starting-style {
+        opacity: 0;
+        scale: 0.98;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .overlay-portal {
+        transition: none;
+
+        @starting-style {
+            opacity: 0;
+            scale: none;
+        }
+    }
 }
 
 /* Placement lives here rather than in OverlayTrigger, which previously wrote

--- a/moo-ds/src/css/components/_tooltip.css
+++ b/moo-ds/src/css/components/_tooltip.css
@@ -33,11 +33,21 @@
     border: var(--tooltip-arrow-size) solid transparent;
 }
 
-/* Portal-rendered tooltip: CSS anchor positioned */
+/* Portal-rendered tooltip: CSS anchor positioned, and promoted into the top
+   layer with popover="manual" so it cannot be trapped under a stacking context
+   or painted beneath a top-layer dialog.
+
+   The [popover] UA styles have to be undone first: it defaults to inset: 0 with
+   margin: auto, which centres the element and fights position-area, plus a
+   border, padding and overflow: auto that would clip the ::after arrow.
+   z-index is kept as the fallback for anything without the popover API. */
 .tooltip-portal {
     position: fixed;
     position-area: top;
-    margin-bottom: var(--tooltip-arrow-size);
+    inset: auto;
+    margin: 0 0 var(--tooltip-arrow-size);
+    border: 0;
+    overflow: visible;
     position-try-fallbacks: flip-block;
 
     /* Fade in on appear. @starting-style supplies the pre-insertion value, so

--- a/moo-ds/src/css/components/_tooltip.css
+++ b/moo-ds/src/css/components/_tooltip.css
@@ -65,9 +65,11 @@
     }
 }
 
+/* Drop the movement, keep the fade: a cross-fade is not motion, and removing
+   the transition outright would make the tooltip snap in. */
 @media (prefers-reduced-motion: reduce) {
     .tooltip-portal {
-        transition: none;
+        transition: opacity 0.15s ease-out;
 
         @starting-style {
             opacity: 0;

--- a/moo-ds/src/css/components/_tooltip.css
+++ b/moo-ds/src/css/components/_tooltip.css
@@ -39,6 +39,41 @@
     position-area: top;
     margin-bottom: var(--tooltip-arrow-size);
     position-try-fallbacks: flip-block;
+
+    /* Fade in on appear. @starting-style supplies the pre-insertion value, so
+       this needs no mount-time class toggle or timer.
+
+       Entry only, deliberately: Tooltip renders the portal as `{show && ...}`,
+       so on hide React removes the node and there is nothing left to transition.
+       Animating the exit as well would mean keeping the tooltip mounted and
+       driving display from CSS, which is a component change rather than a
+       styling one -- see the same note in _combo-box.css and _overlay.css. */
+    transition: opacity 0.15s ease-out, translate 0.15s ease-out;
+
+    @starting-style {
+        opacity: 0;
+        translate: 0 0.25rem;
+    }
+}
+
+/* Flipped below the trigger, so it should rise from the other direction. */
+@container anchored(fallback: flip-block) {
+    .tooltip-portal {
+        @starting-style {
+            translate: 0 -0.25rem;
+        }
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .tooltip-portal {
+        transition: none;
+
+        @starting-style {
+            opacity: 0;
+            translate: none;
+        }
+    }
 }
 
 /* Arrow pointing down (default: tooltip above trigger) */

--- a/moo-ds/src/utils/__tests__/topLayer.test.ts
+++ b/moo-ds/src/utils/__tests__/topLayer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { supportsPopover, topLayerProps } from '../topLayer';
+import { showInTopLayer, supportsPopover, topLayerProps } from '../topLayer';
 
 // jsdom implements no popover API, so the un-patched case is the real default
 // here -- which is exactly the environment the feature detection exists for.
@@ -48,5 +48,41 @@ describe('topLayer', () => {
             withShowPopover(() => {});
             expect(topLayerProps()).toEqual({ popover: 'manual' });
         });
+    });
+});
+
+describe('showInTopLayer', () => {
+    const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'showPopover');
+
+    afterEach(() => {
+        if (original) Object.defineProperty(HTMLElement.prototype, 'showPopover', original);
+        else delete (HTMLElement.prototype as any).showPopover;
+    });
+
+    const withShowPopover = (value: unknown) =>
+        Object.defineProperty(HTMLElement.prototype, 'showPopover', { value, configurable: true, writable: true });
+
+    it('does nothing where the API is absent', () => {
+        delete (HTMLElement.prototype as any).showPopover;
+        expect(() => showInTopLayer(document.createElement('div'))).not.toThrow();
+    });
+
+    // ?.() would have called this and thrown; the typeof guard is what stops it.
+    it('does not call a showPopover that is not a function', () => {
+        withShowPopover('nonsense');
+        expect(() => showInTopLayer(document.createElement('div'))).not.toThrow();
+    });
+
+    it('tolerates a null element', () => {
+        withShowPopover(() => {});
+        expect(() => showInTopLayer(null)).not.toThrow();
+        expect(() => showInTopLayer(undefined)).not.toThrow();
+    });
+
+    it('calls showPopover where it is callable', () => {
+        let called = 0;
+        withShowPopover(function () { called += 1; });
+        showInTopLayer(document.createElement('div'));
+        expect(called).toBe(1);
     });
 });

--- a/moo-ds/src/utils/__tests__/topLayer.test.ts
+++ b/moo-ds/src/utils/__tests__/topLayer.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { supportsPopover, topLayerProps } from '../topLayer';
+
+// jsdom implements no popover API, so the un-patched case is the real default
+// here -- which is exactly the environment the feature detection exists for.
+describe('topLayer', () => {
+    const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'showPopover');
+
+    afterEach(() => {
+        if (original) {
+            Object.defineProperty(HTMLElement.prototype, 'showPopover', original);
+        } else {
+            delete (HTMLElement.prototype as any).showPopover;
+        }
+    });
+
+    const withShowPopover = (value: unknown) =>
+        Object.defineProperty(HTMLElement.prototype, 'showPopover', {
+            value,
+            configurable: true,
+            writable: true,
+        });
+
+    describe('supportsPopover', () => {
+        it('is false when the API is absent', () => {
+            delete (HTMLElement.prototype as any).showPopover;
+            expect(supportsPopover()).toBe(false);
+        });
+
+        it('is true when showPopover is a function', () => {
+            withShowPopover(() => {});
+            expect(supportsPopover()).toBe(true);
+        });
+
+        it('is false when showPopover exists but is not callable', () => {
+            withShowPopover('nonsense');
+            expect(supportsPopover()).toBe(false);
+        });
+    });
+
+    describe('topLayerProps', () => {
+        it('omits the attribute where the API is absent, so the element is not hidden', () => {
+            delete (HTMLElement.prototype as any).showPopover;
+            expect(topLayerProps()).toEqual({});
+        });
+
+        it('applies popover="manual" where the API is present', () => {
+            withShowPopover(() => {});
+            expect(topLayerProps()).toEqual({ popover: 'manual' });
+        });
+    });
+});

--- a/moo-ds/src/utils/index.ts
+++ b/moo-ds/src/utils/index.ts
@@ -4,4 +4,5 @@ export * from "./guid";
 export * from "./paging";
 export * from "./renderingHelpers";
 export * from "./sorting";
+export * from "./topLayer";
 export * from "./trimEnd";

--- a/moo-ds/src/utils/topLayer.ts
+++ b/moo-ds/src/utils/topLayer.ts
@@ -23,3 +23,21 @@ export const supportsPopover = (): boolean =>
  */
 export const topLayerProps = (): { popover?: "manual" } =>
     supportsPopover() ? { popover: "manual" } : {};
+
+/**
+ * Move an element into the top layer, where the API allows it.
+ *
+ * Guards on the element's own method rather than on supportsPopover(), so the
+ * check is against the thing actually being called. Both have to agree: the
+ * popover attribute is only applied where showPopover is callable, so calling
+ * it where it is not would mean invoking the API on an element that never got
+ * the attribute.
+ *
+ * Calling this on an already-open popover is a no-op rather than an error, so
+ * an effect that re-runs does not need to track whether it has already shown.
+ */
+export const showInTopLayer = (element: HTMLElement | null | undefined): void => {
+    if (element && typeof element.showPopover === "function") {
+        element.showPopover();
+    }
+};

--- a/moo-ds/src/utils/topLayer.ts
+++ b/moo-ds/src/utils/topLayer.ts
@@ -1,0 +1,25 @@
+/**
+ * Whether the browser implements the Popover API.
+ *
+ * Overlays that need to sit above everything (tooltips, popovers) render into
+ * the top layer via `popover="manual"` plus `showPopover()`, because a z-index
+ * -- however large -- is still painted below a top-layer element such as an
+ * open `<dialog>`.
+ *
+ * The attribute is applied only when the API is present. A `popover` element
+ * is `display: none` until it is opened, so adding the attribute somewhere
+ * `showPopover()` does not exist (jsdom, or a browser predating the API) would
+ * hide the overlay outright and drop it from the accessibility tree. Feature
+ * detecting keeps those environments on the previous z-index behaviour.
+ */
+export const supportsPopover = (): boolean =>
+    typeof HTMLElement !== "undefined" && typeof HTMLElement.prototype.showPopover === "function";
+
+/**
+ * Spreadable `popover="manual"` attribute, empty where the API is unavailable.
+ * "manual" rather than "auto" because these overlays manage their own
+ * dismissal -- "auto" adds light-dismiss and closes them on any outside click,
+ * which would fight the components' existing open/close state.
+ */
+export const topLayerProps = (): { popover?: "manual" } =>
+    supportsPopover() ? { popover: "manual" } : {};


### PR DESCRIPTION
Groundwork for #657 Tier 1.2 — and the reason that workstream **can't start with the modal**.

> **Stacked on #682** (→ #681). Merge order: #681 → #682 → this.

## Why this has to come first

The overlay z-index ladder deliberately puts tooltips (1080) and popovers (1070) **above** the modal (1055). The native top layer ignores `z-index` entirely — measured, an open dialog paints above `z-index: 2147483647`.

So promoting `Modal` to `<dialog>` while tooltips still rely on z-index would **bury every tooltip and popover opened inside a modal**. Moving them first means that ordering already holds when the modal migration lands.

Verified against a real `<dialog>`: with the trigger inside an open modal, the tooltip paints over the modal's content.

It's also a win today independent of any modal work — both overlays become immune to an ancestor stacking context, which `z-index` alone never was.

## Feature detected, not applied unconditionally

A `[popover]` element is `display: none` until opened. Adding the attribute where `showPopover()` doesn't exist — jsdom, or a browser predating the API — **hides the overlay outright and drops it from the accessibility tree**.

That isn't hypothetical. Applying it unconditionally broke the Tooltip test immediately:

```
TestingLibraryElementError: Unable to find an accessible element with the role "tooltip"
```

`topLayerProps()` omits the attribute in those environments, so they keep the previous behaviour — which is why the `z-index` declarations stay as the fallback. Covered by 5 unit tests including the not-callable edge case.

`"manual"` rather than `"auto"`: auto adds light-dismiss and would close these on any outside click, fighting the components' own open/close state.

## UA styles undone

`[popover]` defaults to `inset: 0` with `margin: auto` — which centres the element and fights `position-area` — plus a border, padding, `Canvas` background and `overflow: auto` that would paint a box behind the content and clip the tooltip's arrow. All reset in CSS.

## A finding recorded for the modal work, not fixed here

`showModal()` makes everything outside the dialog **inert**. An overlay portalled to `document.body` is therefore painted above the modal but is **not hit-testable and leaves the accessibility tree**.

I caught this because my first hit-test showed the tooltip losing — the screenshot then showed it painting correctly on top, so the failure was inertness, not paint order.

For tooltips that's tolerable (they're read via `aria-describedby`), but an **interactive** overlay — the user menu, say — would stop working inside a modal. Those will need to portal into the dialog subtree. Noted in the commit so the modal work inherits it rather than rediscovering it.

## Verification

- `npm run build -w @andrewmclachlan/moo-ds` — clean
- `npm run test:run` — **1709/1709** pass (1704 + 5 new)
- Top-layer paint order confirmed by screenshot against a real `<dialog>`
- Anchor positioning, `position-try-fallbacks` and `@starting-style` all confirmed still working with the popover attribute applied

Refs #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)