### PR TITLE
fix(moo-app): bound interactive redirects across page loads and never redirect from a frame

### DIFF
--- a/moo-app/src/providers/MsalAuthProvider.tsx
+++ b/moo-app/src/providers/MsalAuthProvider.tsx
@@ -30,6 +30,64 @@ const getRedirectState = (client: IPublicClientApplication): RedirectState => {
     return state;
 };
 
+/**
+ * Whether this is the top-level window rather than a frame.
+ *
+ * MSAL renews tokens in a hidden iframe. Unless silentRedirectUri points at a
+ * scriptless page the iframe boots the SPA, so this interceptor runs inside it
+ * -- and an interactive redirect started there navigates the frame rather than
+ * the page, which loops. silentRedirectUri is opt-in and unset by default, so
+ * a consumer that has not configured it, or whose blank page is not yet
+ * registered as a reply URI, has no protection without this check.
+ *
+ * @see https://learn.microsoft.com/en-us/entra/msal/javascript/browser/errors#block_iframe_reload
+ */
+const isTopWindow = (): boolean => {
+    try {
+        return window.self === window.top;
+    } catch {
+        // Reading window.top across origins throws, which only happens framed.
+        return false;
+    }
+};
+
+/**
+ * Bounds *sequential* interactive redirects, which redirectStateByClient
+ * cannot: a redirect discards the page and takes the WeakMap with it, so the
+ * in-memory guard only ever bounds concurrent callers within one page load.
+ * Held in sessionStorage so it survives the navigation, and scoped to the tab
+ * so one tab recovering does not consume another's attempt.
+ */
+const INTERACTIVE_RECOVERY_ATTEMPTED = "mooappInteractiveRecoveryAttempted";
+
+// sessionStorage throws where storage is blocked -- private browsing, some
+// embedded webviews, a restrictive cookie policy. Authentication must not be
+// the thing that breaks there, so each access degrades to "no marker", which
+// restores the previous behaviour rather than blocking recovery outright.
+const interactiveRecoveryAttempted = (): boolean => {
+    try {
+        return sessionStorage.getItem(INTERACTIVE_RECOVERY_ATTEMPTED) !== null;
+    } catch {
+        return false;
+    }
+};
+
+const markInteractiveRecoveryAttempted = (): void => {
+    try {
+        sessionStorage.setItem(INTERACTIVE_RECOVERY_ATTEMPTED, "1");
+    } catch {
+        // Storage unavailable; the in-memory guard still bounds concurrent callers.
+    }
+};
+
+const clearInteractiveRecoveryAttempt = (): void => {
+    try {
+        sessionStorage.removeItem(INTERACTIVE_RECOVERY_ATTEMPTED);
+    } catch {
+        // Nothing to clear if it could never be written.
+    }
+};
+
 /** Marker carried by cancellations raised by the auth interceptors. */
 const authCancellationMarker = Symbol.for("mooapp.authCancellation");
 
@@ -167,10 +225,34 @@ const handleSilentFailure = async (
         throw authCanceledError("Request canceled: unable to acquire authentication token.");
     }
 
+    // A silent-renewal iframe has no user to interact with, and redirecting
+    // from one navigates the frame rather than the page. Cancel quietly: the
+    // frame is discarded either way, so logging a failure per renewal would be
+    // noise.
+    if (!isTopWindow()) {
+        throw authCanceledError("Request canceled: silent renewal cannot start an interactive redirect.");
+    }
+
     // For any MSAL auth error (expired tokens, consent required, iframe
     // timeouts, etc.), fall back to interactive redirect.
     const redirectState = getRedirectState(msal.instance);
     if (!redirectState.redirectInFlight && msal.inProgress === InteractionStatus.None) {
+
+        // We have already been through an interactive redirect in this tab and
+        // are still failing, so another cannot help -- a corrupt cache entry, a
+        // scope that cannot be consented, an unsatisfiable Conditional Access
+        // policy. Surface the underlying error rather than cancelling:
+        // authCanceledError feeds MooApp's retry policy, which would leave the
+        // app sitting on a loading state instead of showing what went wrong.
+        if (interactiveRecoveryAttempted()) {
+            console.error(
+                "Token acquisition still requires interaction after an interactive redirect; not redirecting again.",
+                error,
+            );
+            throw error;
+        }
+
+        markInteractiveRecoveryAttempted();
         redirectState.redirectInFlight = true;
         const interactiveScopes = Array.from(new Set([...(loginRequest.scopes ?? []), ...scopes]));
         try {
@@ -181,6 +263,9 @@ const handleSilentFailure = async (
             });
         } catch (redirectError) {
             redirectState.redirectInFlight = false;
+            // Nothing navigated, so the attempt was not spent. Leaving the
+            // marker set would disable recovery for the rest of the tab's life.
+            clearInteractiveRecoveryAttempt();
             throw redirectError;
         }
     }
@@ -205,6 +290,11 @@ const acquireTokenForRequest = async (
     catch (error) {
         return handleSilentFailure(error, msal, scopes, tokenRequest);
     }
+
+    // Silent acquisition works again, so the bound is spent rather than
+    // permanent -- a token expiring hours from now must still be able to
+    // recover interactively.
+    clearInteractiveRecoveryAttempt();
 
     if (token.accessToken) {
         request.headers.setAuthorization(`Bearer ${token.accessToken}`);
@@ -261,6 +351,9 @@ const retryAfterUnauthorized = async (
     catch (refreshError) {
         return handleSilentFailure(refreshError, msal, scopes, tokenRequest);
     }
+
+    // As on the request path: a working refresh releases the bound.
+    clearInteractiveRecoveryAttempt();
 
     if (!token.accessToken) {
         throw error;

--- a/moo-app/src/providers/MsalAuthProvider.tsx
+++ b/moo-app/src/providers/MsalAuthProvider.tsx
@@ -46,7 +46,10 @@ const isTopWindow = (): boolean => {
     try {
         return window.self === window.top;
     } catch {
-        // Reading window.top across origins throws, which only happens framed.
+        // Two ways in: reading window.top across origins throws, which only
+        // happens when framed; and window itself is undefined outside a browser.
+        // false is the safe answer to both -- there is nowhere to redirect to in
+        // either case, so the caller cancels instead of trying.
         return false;
     }
 };

--- a/moo-app/src/providers/__tests__/MsalAuthProvider.test.tsx
+++ b/moo-app/src/providers/__tests__/MsalAuthProvider.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import axios from 'axios';
 import { AuthError } from '@azure/msal-browser';
@@ -102,6 +102,9 @@ describe('addMsalInterceptor', () => {
 
   beforeEach(() => {
     mockGetSilentRedirectUri.mockReturnValue(undefined);
+    // The interactive-recovery bound is deliberately persistent (see #675), so
+    // it survives between cases unless cleared.
+    sessionStorage.clear();
   });
 
   it('adds a request interceptor to the client', () => {
@@ -258,6 +261,117 @@ describe('addMsalInterceptor', () => {
       expect(isAuthCancellation(undefined)).toBe(false);
     });
   });
+
+  // A redirect discards the page, so the in-memory WeakMap guard cannot bound
+  // sequential redirects -- only concurrent ones within a single page load.
+  // sessionStorage survives the navigation, which is what stops the loop.
+  describe('bounding redirects across page loads (#675)', () => {
+    it('redirects once, then surfaces the error rather than redirecting again', async () => {
+      const authError = new AuthError('interaction_required');
+
+      // First page load: silent fails, we redirect.
+      const first = createMockMsal({ acquireTokenSilent: vi.fn().mockRejectedValue(authError) });
+      await expect(createClientWithInterceptor(first).get('/api/data')).rejects.toThrow('Request canceled');
+      expect(first.instance.acquireTokenRedirect).toHaveBeenCalledTimes(1);
+
+      // After the redirect the page is new: module state is gone, so a fresh
+      // mock stands in for it. Only sessionStorage carries over.
+      const second = createMockMsal({ acquireTokenSilent: vi.fn().mockRejectedValue(authError) });
+      const rejection = await createClientWithInterceptor(second).get('/api/data').catch((e) => e);
+
+      expect(second.instance.acquireTokenRedirect).not.toHaveBeenCalled();
+      expect(rejection).toBe(authError);
+      // Surfaced, not cancelled -- a cancellation feeds the retry policy and
+      // the app would hang on a loading state instead of showing the failure.
+      expect(isAuthCancellation(rejection)).toBe(false);
+    });
+
+    it('releases the bound once silent acquisition works again', async () => {
+      const authError = new AuthError('interaction_required');
+
+      const failing = createMockMsal({ acquireTokenSilent: vi.fn().mockRejectedValue(authError) });
+      await expect(createClientWithInterceptor(failing).get('/api/data')).rejects.toThrow('Request canceled');
+
+      // A later success means the bound is spent, not permanent.
+      const working = createMockMsal({ acquireTokenSilent: vi.fn().mockResolvedValue({ accessToken: 'tok' }) });
+      await createClientWithInterceptor(working).get('/api/data');
+
+      // So a genuine expiry hours later can still recover interactively.
+      const later = createMockMsal({ acquireTokenSilent: vi.fn().mockRejectedValue(authError) });
+      await expect(createClientWithInterceptor(later).get('/api/data')).rejects.toThrow('Request canceled');
+      expect(later.instance.acquireTokenRedirect).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not spend the attempt when the redirect never starts', async () => {
+      const authError = new AuthError('interaction_required');
+      const redirectFailure = new Error('redirect could not start');
+
+      const broken = createMockMsal({
+        acquireTokenSilent: vi.fn().mockRejectedValue(authError),
+        acquireTokenRedirect: vi.fn().mockRejectedValue(redirectFailure),
+      });
+      await expect(createClientWithInterceptor(broken).get('/api/data')).rejects.toThrow('redirect could not start');
+
+      // Nothing navigated, so recovery must still be available.
+      const retry = createMockMsal({ acquireTokenSilent: vi.fn().mockRejectedValue(authError) });
+      await expect(createClientWithInterceptor(retry).get('/api/data')).rejects.toThrow('Request canceled');
+      expect(retry.instance.acquireTokenRedirect).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // MSAL renews tokens in a hidden iframe. Unless silentRedirectUri points at a
+  // scriptless page -- which is opt-in and unset by default -- that iframe boots
+  // the SPA, so this interceptor runs inside it and a redirect started here
+  // navigates the frame rather than the page.
+  describe('not redirecting from inside a frame (#676)', () => {
+    const framed = (topValue: unknown) =>
+      Object.defineProperty(window, 'top', { value: topValue, configurable: true });
+
+    afterEach(() => {
+      Object.defineProperty(window, 'top', { value: window.self, configurable: true });
+    });
+
+    it('cancels instead of redirecting when not the top window', async () => {
+      framed({});   // some other window: we are framed
+      const msal = createMockMsal({
+        acquireTokenSilent: vi.fn().mockRejectedValue(new AuthError('interaction_required')),
+      });
+
+      const rejection = await createClientWithInterceptor(msal).get('/api/data').catch((e) => e);
+
+      expect(msal.instance.acquireTokenRedirect).not.toHaveBeenCalled();
+      expect(rejection.message).toContain('silent renewal cannot start an interactive redirect');
+      // Cancelled rather than surfaced: there is no user in the frame, and the
+      // frame is discarded either way.
+      expect(isAuthCancellation(rejection)).toBe(true);
+    });
+
+    it('does not spend the interactive-recovery attempt while framed', async () => {
+      framed({});
+      const inFrame = createMockMsal({
+        acquireTokenSilent: vi.fn().mockRejectedValue(new AuthError('interaction_required')),
+      });
+      await expect(createClientWithInterceptor(inFrame).get('/api/data')).rejects.toThrow('silent renewal');
+
+      // The top window must still be able to recover.
+      Object.defineProperty(window, 'top', { value: window.self, configurable: true });
+      const topWindow = createMockMsal({
+        acquireTokenSilent: vi.fn().mockRejectedValue(new AuthError('interaction_required')),
+      });
+      await expect(createClientWithInterceptor(topWindow).get('/api/data')).rejects.toThrow('Request canceled');
+      expect(topWindow.instance.acquireTokenRedirect).toHaveBeenCalledTimes(1);
+    });
+
+    it('redirects normally in the top window', async () => {
+      const msal = createMockMsal({
+        acquireTokenSilent: vi.fn().mockRejectedValue(new AuthError('interaction_required')),
+      });
+
+      await expect(createClientWithInterceptor(msal).get('/api/data')).rejects.toThrow('Request canceled');
+
+      expect(msal.instance.acquireTokenRedirect).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 describe('401 response recovery', () => {
@@ -299,6 +413,9 @@ describe('401 response recovery', () => {
 
   beforeEach(() => {
     mockGetSilentRedirectUri.mockReturnValue(undefined);
+    // The interactive-recovery bound is deliberately persistent (see #675), so
+    // it survives between cases unless cleared.
+    sessionStorage.clear();
   });
 
   it('force-refreshes the token and retries once on 401', async () => {


### PR DESCRIPTION
Closes #675 and #676 — two distinct routes into the same reboot loop, both in `handleSilentFailure`.

## #675 — the in-memory guard cannot bound *sequential* redirects

`redirectStateByClient` is a module-level `WeakMap`. A redirect **discards the page**, taking the map with it, and `HANDLE_REDIRECT_END` clears `redirectInFlight` on the way back anyway. So if `acquireTokenSilent` still throws a recoverable `AuthError` after a completed redirect, nothing stops it redirecting again — indefinitely.

A `sessionStorage` marker survives the navigation. **Both guards are needed and aren't interchangeable:** the `WeakMap` stops a page's concurrent callers stampeding one redirect; the marker stops the sequence.

Three details, each of which the issue called out and each of which matters:

- **Released on success**, on the request path *and* after a 401 force-refresh — so the bound is "one attempt per unrecovered failure", not "one per tab, ever". A genuine expiry hours later must still recover.
- **Released if the redirect never starts** — nothing navigated, so the attempt wasn't spent. Leaving it set would disable recovery for the tab's life.
- **Surfaces the original `AuthError`, not a cancellation.** `authCanceledError` feeds `MooApp`'s `isAuthCancellation` retry policy, which would keep the query pending — trading the loop for a hang, with no more diagnostic value.

## #676 — never redirect from a frame

`silentRedirectUri` is opt-in and **unset by default**, so #607's fix doesn't protect a consumer who hasn't configured it, or whose blank page isn't yet registered as a SPA reply URI. In those cases the renewal iframe boots the SPA, this interceptor runs inside it, and the redirect navigates the frame.

A `window.self === window.top` check closes that for everyone, with no configuration and no reply-URI registration. It cancels rather than surfacing — there's no user in a frame to interact with, and the frame is discarded either way, so a logged failure per renewal would be noise.

## Storage access is wrapped

`sessionStorage` throws where storage is blocked — private browsing, some embedded webviews, restrictive cookie policies. Authentication must not be the thing that breaks there, so every access degrades to "no marker", restoring the previous behaviour rather than blocking recovery outright.

## Verification

Six tests, and they bite — removing the two guards fails **exactly** the loop-bound case, the framed case, and the not-spent-when-the-redirect-fails case, leaving the other 27 green.

Including the case #675 asks for explicitly: two consecutive recoverable `AuthError`s with `sessionStorage` persisting between them produce **exactly one** `acquireTokenRedirect`, and the second attempt rejects with the original error rather than a cancellation.

The existing suite needed `sessionStorage.clear()` between cases — itself evidence the marker survives as intended.

- `npm run build -w @andrewmclachlan/moo-app` — clean
- `npm run test:run` — 1743/1743 pass

> Note: `npm run type-check` currently fails on `main` with 3 pre-existing errors in **test** files (from #679 and #686). CI can't see them — it runs vitest through esbuild and builds only library sources. Fixed separately rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)