### PR TITLE
fix(moo-app): pass the required correlationId to AuthError in the MSAL tests

### DIFF
--- a/moo-app/src/providers/__tests__/MsalAuthProvider.test.tsx
+++ b/moo-app/src/providers/__tests__/MsalAuthProvider.test.tsx
@@ -267,7 +267,7 @@ describe('addMsalInterceptor', () => {
   // sessionStorage survives the navigation, which is what stops the loop.
   describe('bounding redirects across page loads (#675)', () => {
     it('redirects once, then surfaces the error rather than redirecting again', async () => {
-      const authError = new AuthError('interaction_required');
+      const authError = new AuthError('interaction_required', 'correlation-id');
 
       // First page load: silent fails, we redirect.
       const first = createMockMsal({ acquireTokenSilent: vi.fn().mockRejectedValue(authError) });
@@ -287,7 +287,7 @@ describe('addMsalInterceptor', () => {
     });
 
     it('releases the bound once silent acquisition works again', async () => {
-      const authError = new AuthError('interaction_required');
+      const authError = new AuthError('interaction_required', 'correlation-id');
 
       const failing = createMockMsal({ acquireTokenSilent: vi.fn().mockRejectedValue(authError) });
       await expect(createClientWithInterceptor(failing).get('/api/data')).rejects.toThrow('Request canceled');
@@ -303,7 +303,7 @@ describe('addMsalInterceptor', () => {
     });
 
     it('does not spend the attempt when the redirect never starts', async () => {
-      const authError = new AuthError('interaction_required');
+      const authError = new AuthError('interaction_required', 'correlation-id');
       const redirectFailure = new Error('redirect could not start');
 
       const broken = createMockMsal({
@@ -334,7 +334,7 @@ describe('addMsalInterceptor', () => {
     it('cancels instead of redirecting when not the top window', async () => {
       framed({});   // some other window: we are framed
       const msal = createMockMsal({
-        acquireTokenSilent: vi.fn().mockRejectedValue(new AuthError('interaction_required')),
+        acquireTokenSilent: vi.fn().mockRejectedValue(new AuthError('interaction_required', 'correlation-id')),
       });
 
       const rejection = await createClientWithInterceptor(msal).get('/api/data').catch((e) => e);
@@ -349,14 +349,14 @@ describe('addMsalInterceptor', () => {
     it('does not spend the interactive-recovery attempt while framed', async () => {
       framed({});
       const inFrame = createMockMsal({
-        acquireTokenSilent: vi.fn().mockRejectedValue(new AuthError('interaction_required')),
+        acquireTokenSilent: vi.fn().mockRejectedValue(new AuthError('interaction_required', 'correlation-id')),
       });
       await expect(createClientWithInterceptor(inFrame).get('/api/data')).rejects.toThrow('silent renewal');
 
       // The top window must still be able to recover.
       Object.defineProperty(window, 'top', { value: window.self, configurable: true });
       const topWindow = createMockMsal({
-        acquireTokenSilent: vi.fn().mockRejectedValue(new AuthError('interaction_required')),
+        acquireTokenSilent: vi.fn().mockRejectedValue(new AuthError('interaction_required', 'correlation-id')),
       });
       await expect(createClientWithInterceptor(topWindow).get('/api/data')).rejects.toThrow('Request canceled');
       expect(topWindow.instance.acquireTokenRedirect).toHaveBeenCalledTimes(1);
@@ -364,7 +364,7 @@ describe('addMsalInterceptor', () => {
 
     it('redirects normally in the top window', async () => {
       const msal = createMockMsal({
-        acquireTokenSilent: vi.fn().mockRejectedValue(new AuthError('interaction_required')),
+        acquireTokenSilent: vi.fn().mockRejectedValue(new AuthError('interaction_required', 'correlation-id')),
       });
 
       await expect(createClientWithInterceptor(msal).get('/api/data')).rejects.toThrow('Request canceled');


### PR DESCRIPTION
## Why

`main` is red. The `npm run type-check` step added in #689 runs after the build, and on its first run against `main` it caught seven calls added by #688:

```
moo-app/src/providers/__tests__/MsalAuthProvider.test.tsx(270,25): error TS2554: Expected 2-4 arguments, but got 1.
... (290, 306, 337, 352, 359, 367)
```

`AuthError`'s constructor in `@azure/msal-common` 16.x is `(errorCode, correlationId, errorMessage?, suberror?)` — the second argument is **not** optional, and `new AuthError('interaction_required')` does not compile.

This is the exact blind spot #689 was opened to close: vitest strips types with esbuild rather than checking them, and the library build compiles `src` minus tests, so these ran green in the test step and never reached a type checker. The new step is doing its job on its first outing — it just happened to fire on a PR that had already merged.

## What

Supplies the missing `correlationId` on the seven affected calls. The provider only ever reads `errorCode` off the error (`MsalAuthProvider.tsx:217`), so the value is immaterial; a named literal makes it clear which slot is being filled rather than repeating the error code into it, which is what some of the older lines in this file do.

## Verification

- `npm run type-check` — exit 0 across all four projects (was exit 1)
- `MsalAuthProvider.test.tsx` — 30/30 pass
- Full suite — 1743/1743 pass, 133 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)