### PR TITLE
feat(moo-ds): put the offcanvas panel and its backdrop in the top layer

### DIFF
--- a/demoo/src/routes/layout/Drawer.tsx
+++ b/demoo/src/routes/layout/Drawer.tsx
@@ -7,6 +7,7 @@ export const DrawerPage = () => {
 
     const [showLeftDrawer, setShowLeftDrawer] = useState(false);
     const [showRightDrawer, setShowRightDrawer] = useState(false);
+    const [showRival, setShowRival] = useState(false);
 
     return (
         <Page title="Drawer" breadcrumbs={[{ route: "/layout/page-sections", text: "Layout" }, { route: "/layout/drawer", text: "Drawer" }]} navItems={layoutNav}>
@@ -48,6 +49,22 @@ export const DrawerPage = () => {
                         <p><strong>Description:</strong> This is a detailed view of the selected item shown in a right-side drawer.</p>
                     </Drawer.Body>
                 </Drawer>
+            </Section>
+
+            <Section title="Stacking" header="Above everything else" headerSize={4}>
+                <p>
+                    The panel and its dimming both render in the browser&rsquo;s top layer, so page
+                    content cannot cover them. Show the panel below &mdash; it sits at the highest
+                    <code> z-index</code> a page can use &mdash; then open a drawer. The drawer still
+                    paints over it; the fallback <code>z-index</code> of 1045 would lose.
+                </p>
+                <div className="demo-row">
+                    <Button variant="outline-primary" onClick={() => setShowRival(!showRival)}>
+                        {showRival ? "Hide panel" : "Show panel"}
+                    </Button>
+                    <Button variant="outline-secondary" onClick={() => setShowLeftDrawer(true)}>Open Left Drawer</Button>
+                </div>
+                {showRival && <div className="stacking-rival">z-index: 2147483647</div>}
             </Section>
 
         </Page>

--- a/moo-ds/src/components/Drawer.tsx
+++ b/moo-ds/src/components/Drawer.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
-import React, { useEffect } from "react";
+import React, { useEffect, useLayoutEffect, useRef } from "react";
 import { createPortal } from "react-dom";
+import { hideFromTopLayer, showInTopLayer, topLayerProps } from "../utils/topLayer";
 
 export interface DrawerProps extends React.HTMLAttributes<HTMLDivElement> {
     show: boolean;
@@ -35,6 +36,9 @@ DrawerBody.displayName = "Drawer.Body";
 
 const DrawerComponent: React.FC<React.PropsWithChildren<DrawerProps>> = ({ show, onHide, placement = "start", className, children, ...rest }) => {
 
+    const panelRef = useRef<HTMLDivElement>(null);
+    const backdropRef = useRef<HTMLDivElement>(null);
+
     useEffect(() => {
         if (show) {
             document.body.style.overflow = "hidden";
@@ -43,6 +47,29 @@ const DrawerComponent: React.FC<React.PropsWithChildren<DrawerProps>> = ({ show,
         }
         return () => { document.body.style.overflow = ""; };
     }, [show]);
+
+    // Put the panel and its backdrop in the top layer, so neither can be
+    // covered by page content however high its z-index. The backdrop goes
+    // first: the top layer stacks in the order elements are promoted, so
+    // promoting it before the panel keeps the dimming behind it.
+    //
+    // Nothing is taken back out on close. The panel keeps sliding for 0.3s
+    // after .show is removed, and leaving the top layer mid-slide would drop it
+    // behind any higher-stacked page content for the rest of the animation.
+    // Both are inert while closed anyway -- the panel is visibility: hidden and
+    // the backdrop display: none -- so staying there costs nothing.
+    useLayoutEffect(() => {
+        if (!show) return;
+
+        showInTopLayer(backdropRef.current);
+        showInTopLayer(panelRef.current);
+    }, [show]);
+
+    // Released on unmount rather than on close, for the reason above.
+    useLayoutEffect(() => () => {
+        hideFromTopLayer(panelRef.current);
+        hideFromTopLayer(backdropRef.current);
+    }, []);
 
     // Inject onHide into Header children
     const enhancedChildren = React.Children.map(children, (child) => {
@@ -55,14 +82,21 @@ const DrawerComponent: React.FC<React.PropsWithChildren<DrawerProps>> = ({ show,
     return (
         <>
             <div
+                ref={panelRef}
                 className={classNames("offcanvas", `offcanvas-${placement}`, show && "show", className)}
                 tabIndex={-1}
                 {...rest}
+                {...topLayerProps()}
             >
                 {enhancedChildren}
             </div>
-            {show && createPortal(
-                <div className="offcanvas-backdrop show" onClick={onHide} />,
+            {createPortal(
+                <div
+                    ref={backdropRef}
+                    className={classNames("offcanvas-backdrop", show && "show")}
+                    onClick={onHide}
+                    {...topLayerProps()}
+                />,
                 document.body
             )}
         </>

--- a/moo-ds/src/components/__tests__/Drawer.test.tsx
+++ b/moo-ds/src/components/__tests__/Drawer.test.tsx
@@ -14,14 +14,18 @@ describe('Drawer', () => {
       expect(container.querySelector('.offcanvas.show')).not.toBeInTheDocument();
     });
 
-    it('renders backdrop when show is true', () => {
+    it('shows the backdrop when show is true', () => {
       const { baseElement } = render(<Drawer show onHide={vi.fn()}><Drawer.Body>Content</Drawer.Body></Drawer>);
-      expect(baseElement.querySelector('.offcanvas-backdrop')).toBeInTheDocument();
+      expect(baseElement.querySelector('.offcanvas-backdrop.show')).toBeInTheDocument();
     });
 
-    it('does not render backdrop when show is false', () => {
+    // The backdrop stays mounted so it can fade out alongside the panel's
+    // slide-out; it is hidden with display rather than unmounted, so the
+    // closed state is the absence of .show rather than of the element.
+    it('hides the backdrop when show is false', () => {
       const { baseElement } = render(<Drawer show={false} onHide={vi.fn()}><Drawer.Body>Content</Drawer.Body></Drawer>);
-      expect(baseElement.querySelector('.offcanvas-backdrop')).not.toBeInTheDocument();
+      expect(baseElement.querySelector('.offcanvas-backdrop')).toBeInTheDocument();
+      expect(baseElement.querySelector('.offcanvas-backdrop.show')).not.toBeInTheDocument();
     });
   });
 

--- a/moo-ds/src/css/components/_offcanvas.css
+++ b/moo-ds/src/css/components/_offcanvas.css
@@ -10,11 +10,34 @@
     --offcanvas-border-width: var(--border-width, 1px);
     --offcanvas-border-colour: var(--border-colour, rgba(0, 0, 0, 0.175));
     --offcanvas-box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
-    --offcanvas-transition: transform 0.3s ease-in-out;
+    /* visibility is transitioned alongside transform so it stays `visible` for
+       the whole duration and only flips at the end. Without it the panel is
+       hidden the instant .show is removed, and the slide-out plays entirely
+       out of sight -- it looked like the panel simply vanished. */
+    --offcanvas-transition: transform 0.3s ease-in-out, visibility 0.3s ease-in-out;
     --offcanvas-title-line-height: 1.5;
 
     position: fixed;
+    /* Undo the [popover] UA box before the placement rules below set their own
+       sides. It defaults to inset: 0 with margin: auto, which centres the panel
+       rather than pinning it to an edge, plus a border and padding of its own.
+       inset comes first here so the bottom/top/left/right that follow win.
+
+       height and overflow matter as much as the box: the UA rule sets
+       height: fit-content, which collapses a full-height panel to the height of
+       its contents, and overflow: auto, which moves the scrollbar off
+       .offcanvas-body and onto the panel. Measured on the demo page: 1522px
+       tall without the attribute, 236px with it. */
+    inset: auto;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    height: auto;
+    overflow: visible;
     bottom: 0;
+    /* Fallback ordering only: the panel is promoted into the top layer, which
+       no z-index can beat. This is what applies where the Popover API is
+       missing and the attribute is therefore not set. */
     z-index: 1045;
     display: flex;
     flex-direction: column;
@@ -74,14 +97,36 @@
     scrollbar-gutter: stable;
 }
 
+/* The backdrop stays mounted and is hidden with display, rather than being
+   unmounted while closed. It has to outlive the close now that the panel's
+   slide-out is actually visible: a backdrop that vanished the moment .show
+   came off would leave the panel sliding away over an undimmed page. display
+   is transitioned with allow-discrete so it survives the fade.
+
+   Promoted into the top layer just before the panel, so the two stay in the
+   right order there -- the top layer stacks by promotion order. */
 .offcanvas-backdrop {
     position: fixed;
+    /* Undo the [popover] UA box: it brings a border, padding, margin: auto and
+       a max-width/height of the viewport minus twice its own inset. inset comes
+       first so the top/left below win. */
+    inset: auto;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    max-width: none;
+    max-height: none;
     top: 0;
     left: 0;
+    /* Fallback ordering only -- see the note on .offcanvas. */
     z-index: 1040;
     width: 100vw;
     height: 100vh;
     background-color: transparent;
+
+    display: none;
+    opacity: 0;
+    transition: opacity 0.3s ease-in-out, display 0.3s allow-discrete;
 }
 
 .offcanvas-backdrop.fade {
@@ -89,14 +134,24 @@
 }
 
 .offcanvas-backdrop.show {
+    display: block;
     opacity: 1;
     backdrop-filter: blur(1px) grayscale(0.5) brightness(0.5);
-    /* The panel itself already slides in over 0.3s; without this the dimming
-       appeared instantly behind it. Matched to the panel's duration so the two
-       arrive together. */
-    transition: opacity 0.3s ease-in-out;
 
     @starting-style {
         opacity: 0;
+    }
+}
+
+/* The slide is the entire animation here, so there is no shorter version to
+   fall back to: reduced motion drops it to a plain appear and disappear.
+   visibility and display still flip, just with nothing to sit through. This
+   matters more than it used to -- the slide-out was previously played while the
+   panel was already hidden, so nobody ever saw it. */
+@media (prefers-reduced-motion: reduce) {
+
+    .offcanvas,
+    .offcanvas-backdrop {
+        transition: none;
     }
 }


### PR DESCRIPTION
Closes #687.

## What

The offcanvas panel competed on `z-index` (1045) and lost to any page content stacked above it. Both the panel and its backdrop now carry `popover` and are promoted with `showPopover()`, putting them in the top layer — above all page content regardless of `z-index`.

The backdrop is promoted first (the top layer stacks by promotion order, so this keeps the dimming behind the panel), and neither is released on close: leaving the top layer mid-slide would drop the panel behind page content for the rest of the animation. Both are inert while closed, so staying there costs nothing. Release happens on unmount.

## Three things #687 did not anticipate

**1. No `allow-discrete` is needed for the panel.** The issue expected the UA rule `[popover]:not(:popover-open) { display: none }` to fight the slide-out. It doesn't — `.offcanvas { display: flex }` is an author rule and beats the UA one, so `display` never becomes `none`. Measured frame by frame: slide-in `x` −400 → 0, slide-out 0 → −400, `display: flex` at every frame. The stated blocker for this change did not hold.

**2. The `[popover]` UA box damages the panel more than expected.** Beyond the border, padding and `margin: auto` centring, it sets:

| property | with `popover` | without |
|---|---|---|
| `height` | `236.1px` | `1522.4px` |
| `overflow` | `auto` | `visible` |

`height: fit-content` collapsed the full-height panel to its content height, and `overflow: auto` moved the scrollbar off `.offcanvas-body` onto the panel. Both are reset alongside the box. An earlier check of mine missed this because it measured only relative movement, so the panel looked fine while it was actually the wrong size.

**3. The slide-out has never been visible.** `visibility` flipped to `hidden` the instant `.show` came off, so the panel spent its whole 0.3s animating out of sight and simply appeared to vanish. `visibility` now transitions alongside `transform`, so it stays `visible` for the duration and flips on arrival — measured `visible` at 80/160/240ms, `hidden` at 320ms.

## Consequences of (3)

Because the slide-out is now real:

- **The backdrop has to outlive the close**, or the panel would slide away over an undimmed page. It stays mounted and is hidden with `display`, transitioned with `allow-discrete` so it can fade out. While closed it is `display: none`, so it cannot intercept clicks — confirmed by hit-testing the viewport centre with the drawer shut, which returns page content.
- **The two backdrop tests** now assert on `.offcanvas-backdrop.show` rather than on the element's presence.
- **Reduced motion needs handling.** The slide is the whole animation, so there is no shorter version to fall back to; it drops to a plain appear and disappear.

## The issue's open question

> The offcanvas tests do the same thing, but its panel does **not** cover the viewport, so a real click should reach `.offcanvas-backdrop`. Worth confirming rather than assuming.

Confirmed: `elementFromPoint` over the dimmed area returns `.offcanvas-backdrop show`, and clicking it dismisses. Unlike the modal, the offcanvas test was already exercising the real path.

## Verification

Measured in the browser against the demo page, both placements:

- **`start`** — open −400 → 0, close 0 → −400, `visible` throughout both, `:popover-open` true
- **`end`** — open 1500 → 1100, close 1100 → 1500, same
- **Backdrop** — `display: block`, opacity 1 → 0.77 → 0.32 → 0.03 → `display: none`, covering 1500×1522
- **Top layer** — against a rival at `z-index: 2147483647` *made hittable for the test* (`.stacking-rival` normally has `pointer-events: none`, which would have made the hit test meaningless): the backdrop wins over the dimmed area, the panel over its own, and the rival is not visible at all behind the panel
- **Closed state** — hit test at viewport centre reaches page content
- Full suite 1743/1743, lint clean

demoo's Drawer page gains the same "above everything else" sample the Overlays page has, reusing `.stacking-rival`.

> [!NOTE]
> `npm run type-check` fails on this branch with 7 pre-existing errors in `MsalAuthProvider.test.tsx` — that is `main` being red, fixed by #690, and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)