### PR TITLE
feat(moo-ds): add Kpi component

### DIFF
--- a/moo-ds/src/components/Kpi.tsx
+++ b/moo-ds/src/components/Kpi.tsx
@@ -1,0 +1,58 @@
+import classNames from "classnames";
+import React from "react";
+import { Section } from "../layout/Section/Section";
+
+/**
+ * Which way a figure reads. Deliberately not domain wording — an app decides whether its
+ * "income" is positive and its "spend" negative, and can repoint the accent per context by
+ * setting `--kpi-accent`.
+ */
+export type KpiTone = "positive" | "negative" | "neutral";
+
+export interface KpiProps extends Omit<React.HTMLAttributes<HTMLElement>, "children"> {
+    /** The small uppercase label above the figure. */
+    label: React.ReactNode;
+    tone?: KpiTone;
+}
+
+export type KpiValueProps = React.HTMLAttributes<HTMLDivElement>;
+
+export type KpiSubProps = React.HTMLAttributes<HTMLDivElement>;
+
+const KpiValue: React.FC<React.PropsWithChildren<KpiValueProps>> = ({ className, children, ...rest }) => (
+    <div className={classNames("kpi-value", className)} {...rest}>
+        {children}
+    </div>
+);
+
+KpiValue.displayName = "Kpi.Value";
+
+const KpiSub: React.FC<React.PropsWithChildren<KpiSubProps>> = ({ className, children, ...rest }) => (
+    <div className={classNames("kpi-sub", className)} {...rest}>
+        {children}
+    </div>
+);
+
+KpiSub.displayName = "Kpi.Sub";
+
+/**
+ * A headline figure on a card with a coloured top edge: a label, the number, and an optional
+ * caption underneath.
+ *
+ * Type sizes are deliberately absent from the component's own CSS — a KPI strip in a page header
+ * and one in a dashboard want different scales, so the consumer sets those against the container
+ * around the cards.
+ */
+const KpiComponent: React.FC<React.PropsWithChildren<KpiProps>> = ({ label, tone = "neutral", className, children, ...rest }) => (
+    <Section className={classNames("kpi", className)} data-tone={tone} {...rest}>
+        <div className="kpi-label">{label}</div>
+        {children}
+    </Section>
+);
+
+KpiComponent.displayName = "Kpi";
+
+export const Kpi = Object.assign(KpiComponent, {
+    Value: KpiValue,
+    Sub: KpiSub,
+});

--- a/moo-ds/src/components/__tests__/Kpi.test.tsx
+++ b/moo-ds/src/components/__tests__/Kpi.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { render } from "../../test-utils";
+import { Kpi } from "../Kpi";
+
+describe("Kpi", () => {
+    it("renders as a section carrying the card and label classes", () => {
+        const { container } = render(<Kpi label="Balance"><Kpi.Value>$1,000</Kpi.Value></Kpi>);
+
+        expect(container.querySelector("section.section.kpi")).toBeInTheDocument();
+        expect(container.querySelector(".kpi-label")).toHaveTextContent("Balance");
+        expect(container.querySelector(".kpi-value")).toHaveTextContent("$1,000");
+    });
+
+    it("defaults to the neutral tone so a figure with no direction gets the plain accent", () => {
+        const { container } = render(<Kpi label="Count"><Kpi.Value>12</Kpi.Value></Kpi>);
+
+        expect(container.querySelector(".kpi")).toHaveAttribute("data-tone", "neutral");
+    });
+
+    it("exposes the tone as an attribute, which is what the accent colour keys off", () => {
+        const { container } = render(<Kpi label="Spend" tone="negative"><Kpi.Value>-$40</Kpi.Value></Kpi>);
+
+        expect(container.querySelector(".kpi")).toHaveAttribute("data-tone", "negative");
+    });
+
+    it("renders an optional caption under the figure", () => {
+        render(<Kpi label="Income"><Kpi.Value>$500</Kpi.Value><Kpi.Sub>this month</Kpi.Sub></Kpi>);
+
+        expect(screen.getByText("this month")).toBeInTheDocument();
+    });
+
+    it("keeps consumer class names alongside its own, so a strip can size its cards", () => {
+        const { container } = render(<Kpi label="Balance" className="wide"><Kpi.Value className="strong">$1</Kpi.Value></Kpi>);
+
+        expect(container.querySelector(".kpi")).toHaveClass("wide");
+        expect(container.querySelector(".kpi-value")).toHaveClass("strong");
+    });
+
+    it("takes a node as the label, so a placeholder can stand in while data loads", () => {
+        const { container } = render(<Kpi label={<span data-testid="placeholder" />}><Kpi.Value>—</Kpi.Value></Kpi>);
+
+        expect(screen.getByTestId("placeholder")).toBeInTheDocument();
+        // Still inside the label box, so it inherits that line's height rather than collapsing.
+        expect(container.querySelector(".kpi-label")).toContainElement(screen.getByTestId("placeholder"));
+    });
+});

--- a/moo-ds/src/components/index.ts
+++ b/moo-ds/src/components/index.ts
@@ -19,6 +19,7 @@ export * from "./form";
 export * from "./Icon";
 export * from "./IconButton";
 export * from "./Input";
+export * from "./Kpi";
 export * from "./InputGroup";
 export * from "./IconLinkButton";
 export * from "./LinkBox";

--- a/moo-ds/src/css/_components.css
+++ b/moo-ds/src/css/_components.css
@@ -9,6 +9,7 @@
 @import "components/_data-grid.css";
 @import "components/_forms.css";
 @import "components/_icon-button.css";
+@import "components/_kpi.css";
 @import "components/_link-box.css";
 @import "components/_modal.css";
 @import "components/_nav.css";

--- a/moo-ds/src/css/components/_kpi.css
+++ b/moo-ds/src/css/components/_kpi.css
@@ -1,0 +1,49 @@
+/* KPI card: a headline figure with a coloured top edge.
+   The accent goes through --kpi-accent rather than being set directly, so an app can repoint it
+   for a whole strip — a ledger app wanting its own income/expense hues, say — without restating
+   the rest of the card. Type sizes are the consumer's: the same card serves a page header and a
+   dashboard at different scales. */
+
+.section.kpi {
+    --kpi-accent: var(--primary);
+
+    border-top: 2px solid var(--kpi-accent);
+}
+
+.section.kpi[data-tone="positive"] {
+    --kpi-accent: var(--success);
+}
+
+.section.kpi[data-tone="negative"] {
+    --kpi-accent: var(--danger);
+}
+
+.kpi-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.7px;
+    text-transform: uppercase;
+    color: var(--body-colour-dim);
+}
+
+.kpi-value {
+    font-weight: 600;
+    letter-spacing: -0.6px;
+    line-height: 1.1;
+    /* Figures in a row of cards should line up, so the digits are fixed-width. */
+    font-variant-numeric: tabular-nums;
+    margin-top: 2px;
+}
+
+.kpi-sub {
+    font-size: 0.75rem;
+    color: var(--body-colour-dim);
+    margin-top: 2px;
+}
+
+/* A placeholder standing in for one of these lines takes that line's own box, so the card is the
+   same height loading or loaded and nothing below it moves. */
+:is(.kpi-label, .kpi-value, .kpi-sub) > .skeleton-text > .skeleton-text-line {
+    height: 1lh;
+    margin-block: 0;
+}

--- a/storybook/src/stories/components/Kpi.stories.tsx
+++ b/storybook/src/stories/components/Kpi.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Kpi, Skeleton } from "@andrewmclachlan/moo-ds";
+
+const meta = {
+    title: "Moo App/Components/Kpi",
+    component: Kpi,
+    parameters: {
+        layout: "padded",
+    },
+    tags: ["autodocs"],
+} satisfies Meta<typeof Kpi>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A single figure. With no tone the accent is the theme's primary colour. */
+export const Default: Story = {
+    args: { label: "Balance" },
+    render: (args) => (
+        <Kpi {...args}>
+            <Kpi.Value>$12,480.55</Kpi.Value>
+            <Kpi.Sub>as at today</Kpi.Sub>
+        </Kpi>
+    ),
+};
+
+/** The tone sets the top edge. Positive and negative are directions, not domain words. */
+export const Tones: Story = {
+    args: { label: "Tone" },
+    render: () => (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: "0.75rem" }}>
+            <Kpi label="Income" tone="positive">
+                <Kpi.Value>$8,200.00</Kpi.Value>
+                <Kpi.Sub>this month</Kpi.Sub>
+            </Kpi>
+            <Kpi label="Expenses" tone="negative">
+                <Kpi.Value>$6,431.90</Kpi.Value>
+                <Kpi.Sub>this month</Kpi.Sub>
+            </Kpi>
+            <Kpi label="Transactions" tone="neutral">
+                <Kpi.Value>184</Kpi.Value>
+                <Kpi.Sub>this month</Kpi.Sub>
+            </Kpi>
+        </div>
+    ),
+};
+
+/**
+ * A strip sets its own type scale against the container, because the same card serves a dense
+ * page header and a roomy summary panel.
+ */
+export const Sized: Story = {
+    args: { label: "Sized" },
+    render: () => (
+        <div className="kpi-story-strip" style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: "0.75rem" }}>
+            <style>{`
+                .kpi-story-strip .section.kpi { padding: 0.75rem 1rem; }
+                .kpi-story-strip .kpi-value { font-size: 1.375rem; }
+            `}</style>
+            <Kpi label="Lowest Balance" tone="negative">
+                <Kpi.Value>-$1,204.00</Kpi.Value>
+                <Kpi.Sub>in March 2027</Kpi.Sub>
+            </Kpi>
+            <Kpi label="Sustainable Income" tone="positive">
+                <Kpi.Value>$61,000</Kpi.Value>
+                <Kpi.Sub>a year, in today&rsquo;s dollars</Kpi.Sub>
+            </Kpi>
+        </div>
+    ),
+};
+
+/**
+ * Placeholders go inside the real label, value and caption, so the card is exactly as tall
+ * loading as it is loaded and nothing below it moves when the data lands.
+ */
+export const Loading: Story = {
+    args: { label: "Loading" },
+    render: () => (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: "0.75rem" }}>
+            {[0, 1, 2].map(i => (
+                <Kpi key={i} label={<Skeleton.Text />}>
+                    <Kpi.Value><Skeleton.Text /></Kpi.Value>
+                    <Kpi.Sub><Skeleton.Text /></Kpi.Sub>
+                </Kpi>
+            ))}
+        </div>
+    ),
+};
+
+/** An app can repoint the accent for a whole strip via --kpi-accent, without restating the card. */
+export const CustomAccent: Story = {
+    args: { label: "Custom accent" },
+    render: () => (
+        <div className="kpi-story-brand" style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: "0.75rem" }}>
+            <style>{`
+                .kpi-story-brand .section.kpi[data-tone="positive"] { --kpi-accent: #3e9156; }
+                .kpi-story-brand .section.kpi[data-tone="negative"] { --kpi-accent: #a4332d; }
+            `}</style>
+            <Kpi label="Income" tone="positive">
+                <Kpi.Value>$8,200.00</Kpi.Value>
+            </Kpi>
+            <Kpi label="Expenses" tone="negative">
+                <Kpi.Value>$6,431.90</Kpi.Value>
+            </Kpi>
+        </div>
+    ),
+};


### PR DESCRIPTION
## Why

Four MooBank features had each grown their own copy of the same card — a headline figure with an uppercase label, a coloured top edge and an optional caption — under four different sets of class names:

| Feature | Wrapper | Label | Value |
|---|---|---|---|
| Transactions | `.section.widget` | `.eyebrow` | `.widget-value` |
| Forecast | `.section.metric` | `.eyebrow` | `.metric-value` |
| Retirement | its own copy of the forecast block | `.eyebrow` | `.metric-value` |
| Budget | a bare `div` | `.kpi-label` | `.kpi-value` |

## What

`Kpi`, with `Kpi.Value` and `Kpi.Sub` as compound members, following the existing `Popover.Header/Body` and `Skeleton.Text/Rect` pattern.

Two things kept it design-system-neutral rather than a straight lift:

**Tone is a direction, not a domain.** `positive | negative | neutral`, not income/expense. The accent routes through a `--kpi-accent` custom property defaulting to `--primary`, with `--success` / `--danger` for the two directions, so an app repoints a whole strip in one line:

```css
.tx-compact-widgets .section.kpi[data-tone="positive"] { --kpi-accent: var(--income-bar); }
```

**Type sizes are the consumer's.** A KPI in a dense page header and one in a summary panel want different scales — that split already exists across the four call sites — so the component ships the structure, accent and rhythm and leaves `font-size` to the container.

It also carries a `1lh` rule so a `Skeleton.Text` placed inside the label, value or caption takes that line's exact box. A card is then the same height loading as loaded, and nothing below it shifts when data lands.

## Contents

- `moo-ds/src/components/Kpi.tsx`
- `moo-ds/src/css/components/_kpi.css` (+ import in `_components.css`)
- `moo-ds/src/components/__tests__/Kpi.test.tsx` — 6 tests
- `storybook/src/stories/components/Kpi.stories.tsx` — Default, Tones, Sized, Loading, CustomAccent
- Export from `components/index.ts`

## Verification

- 1752 tests pass across 134 files (6 new)
- `npm run build -w @andrewmclachlan/moo-ds` succeeds; `kpi` rules present in `dist/index.css`, compound type emitted in `Kpi.d.ts`
- Lint: 0 errors

Not visually reviewed in Storybook — worth a look at the stories before merge.

## Follow-up

MooBank currently carries an app-local copy of this component. Once this publishes, that copy and its stylesheet should be deleted and the four sites repointed here — largely renaming `.eyebrow` to `.kpi-label` and mapping income/expense to positive/negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)