### PR TITLE
Fix root build order: build moo-icons before the workspaces that depend on it

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "demoo": "npm run dev --workspace=demoo",
     "start": "npm run dev --workspace=demoo",
     "storybook": "npm run storybook --workspace=storybook",
-    "build": "npm run build --workspaces",
+    "build": "npm run build --workspace=moo-icons && npm run build --workspaces",
     "prelint": "node scripts/link-eslint-typescript.mjs",
     "lint": "npm run lint --workspaces --if-present",
     "prelint-fix": "node scripts/link-eslint-typescript.mjs",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "demoo": "npm run dev --workspace=demoo",
     "start": "npm run dev --workspace=demoo",
     "storybook": "npm run storybook --workspace=storybook",
-    "build": "npm run build --workspace=moo-icons && npm run build --workspaces",
+    "build": "npm run build --workspace=moo-icons --workspace=moo-ds --workspace=moo-app --workspace=demoo --workspace=storybook",
     "prelint": "node scripts/link-eslint-typescript.mjs",
     "lint": "npm run lint --workspaces --if-present",
     "prelint-fix": "node scripts/link-eslint-typescript.mjs",


### PR DESCRIPTION
Fixes the failing Azure Static Web Apps deploy on `main` ([run 30999361310](https://github.com/AndrewMcLachlan/MooApp/actions/runs/30999361310/job/92284126026)).

## Cause

The root script was:

```json
"build": "npm run build --workspaces"
```

`npm run --workspaces` executes in **`workspaces` array order** — `moo-ds`, `moo-app`, `moo-icons`. So `moo-ds` built before the package it now depends on, and its declaration build had no `moo-icons/dist/index.d.ts` to type `Tooltip.tsx` against:

```
src/components/Tooltip.tsx:5:29 - error TS2307: Cannot find module
'@andrewmclachlan/moo-icons' or its corresponding type declarations.
```

SWA surfaced it because Oryx runs the root `build` script on a clean checkout, but **this is not workflow-specific**: `npm run build` fails the same way for anyone who doesn't happen to have a stale `moo-icons/dist` lying around. `moo-icons/dist` is gitignored with no tracked files, so a fresh clone never has one.

Same root cause as the "Build and Publish" failure fixed in `ca07fac`, in a second place. That fix reordered the CI workflow; this one fixes the underlying script, so the ordering holds wherever `npm run build` is invoked.

## Fix

```json
"build": "npm run build --workspace=moo-icons --workspace=moo-ds --workspace=moo-app --workspace=demoo --workspace=storybook"
```

npm honours the order of `--workspace` flags — verified by passing them reversed and watching it comply — so naming them in dependency order gets the guarantee with each package built exactly once.

## Why not something less manual

npm **does not topologically sort** `--workspaces`. Tested directly: adding `@andrewmclachlan/moo-icons` to `moo-ds`'s `devDependencies` made no difference, it still ran in array order. So npm offers no help here and the order has to be imposed by hand.

Alternatives considered:

- **`-w moo-icons && --workspaces`** — also correct and immune to drift, but rebuilds `moo-icons` (~4.6s wasted).
- **Reordering the `workspaces` array** — free, but array ordering is behaviour rather than contract. If it ever changes you get this same baffling `TS2307` back.
- **An orchestrator** (turbo/nx/wireit) — derives order from the dependency graph and is the honest long-term answer now that there are real inter-package build deps. Too big a change for five workspaces today.

**Known trade:** a newly added workspace must be added to this list or it silently never builds. Accepted deliberately — workspaces are added very rarely, and the list sits directly below the `workspaces` array where the omission is visible.

## Verification

Reproduced and fixed against a genuinely clean state rather than assumed. With `moo-icons/dist` moved aside:

- `npm run build --workspaces` (old) → fails with the exact `TS2307` above
- `npm run build` (new) → exits 0, log confirms `moo-icons` builds first and nothing builds twice

Also green: `test:run` (1797 tests), `lint`, `type-check`.

## Aside, not fixed here

`moo-icons` is declared only as a `peerDependency` of `moo-ds` — nothing in `dependencies` or `devDependencies`. Peer is right for consumers, but inside the monorepo `moo-ds` needs it at build time and no manifest says so. It wouldn't change build ordering (tested above), but it would make the relationship visible. Separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
