### PR TITLE
Make the Vite/Vitest configs load natively as ESM

### DIFF
--- a/moo-app/vitest.config.ts
+++ b/moo-app/vitest.config.ts
@@ -6,8 +6,11 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      // Resolve to local source for testing without requiring build
-      '@andrewmclachlan/moo-ds': path.resolve(__dirname, '../moo-ds/src'),
+      // Resolve to local source for testing without requiring build.
+      // import.meta.dirname, not __dirname: this package is "type": "module",
+      // so __dirname exists only via Vite's config bundling — it disappears
+      // under configLoader: 'native'.
+      '@andrewmclachlan/moo-ds': path.resolve(import.meta.dirname, '../moo-ds/src'),
     },
   },
   test: {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.2.0",
   "description": "A collection of packages for the MooApp framework",
   "private": true,
+  "type": "module",
   "workspaces": [
     "moo-ds",
     "moo-app",

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -1,5 +1,5 @@
 import type { StorybookConfig } from '@storybook/react-vite';
-import { resolve } from "path"
+import { resolve } from 'path';
 
 const config: StorybookConfig = {
   "stories": [

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -1,8 +1,5 @@
 import type { StorybookConfig } from '@storybook/react-vite';
-import { dirname, resolve } from "path"
-import { fileURLToPath } from "url"
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+import { resolve } from "path"
 
 const config: StorybookConfig = {
   "stories": [
@@ -29,9 +26,9 @@ const config: StorybookConfig = {
     config.resolve = config.resolve || {};
     config.resolve.alias = {
       ...config.resolve.alias,
-      '@andrewmclachlan/moo-ds': resolve(__dirname, '../../moo-ds/src'),
-      '@andrewmclachlan/moo-app': resolve(__dirname, '../../moo-app/src'),
-      '@andrewmclachlan/moo-icons': resolve(__dirname, '../../moo-icons/src'),
+      '@andrewmclachlan/moo-ds': resolve(import.meta.dirname, '../../moo-ds/src'),
+      '@andrewmclachlan/moo-app': resolve(import.meta.dirname, '../../moo-app/src'),
+      '@andrewmclachlan/moo-icons': resolve(import.meta.dirname, '../../moo-icons/src'),
     };
 
     config.build = config.build || {};


### PR DESCRIPTION
Clears both warnings about `configLoader: 'native'`, which is planned to become the Vite default in a future major version. Nothing is broken today — these are forward-looking notices.

The two warnings had **different causes**, despite both citing "vitest.config.ts":

## 1. Root config loaded as CommonJS

```
ESM syntax in a file loaded as CommonJS (vitest.config.ts:1:1)
```

All five workspaces already declare `"type": "module"`. Only the **root** `package.json` didn't, so the root `vitest.config.ts` — which is pure ESM syntax — was being loaded as CommonJS. Added `"type": "module"` to the root.

Checked what else that could affect: every eslint config in the repo is already `.mjs`, and the only root-level script is `scripts/link-eslint-typescript.mjs`. Nothing at the root is interpreted as CommonJS `.js`.

## 2. `__dirname` in an ESM package

```
`__dirname` (vitest.config.ts:10:47). Use `import.meta.dirname` instead
```

This one is `moo-app/vitest.config.ts`, not the root — `moo-ds/vitest.config.ts` has no `__dirname` at all. `moo-app` *is* `"type": "module"`, so `__dirname` shouldn't exist there; it works only because Vite bundles the config and shims it. Under the native loader it disappears. Now `import.meta.dirname`.

## Also

`storybook/.storybook/main.ts` hand-rolled the same shim:

```ts
const __dirname = dirname(fileURLToPath(import.meta.url));
```

Not warned, and correct today, but it's exactly what the built-in now provides — so it goes too, along with two imports. Easy to drop from this PR if you'd rather keep the change to just the warned files.

Node `>= 22` is already required, comfortably above `import.meta.dirname`'s 20.11.

## Verification

- Captured the warnings before the change, confirmed **both are gone** after.
- `test:run` — 1797 tests across 136 files, `lint`, `build`, `type-check` all pass.
- Storybook builds and produces `storybook-static`, which exercises the changed alias config. `path.resolve` throws on `undefined`, so a successful build proves `import.meta.dirname` actually resolves rather than silently being empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
