### PR TITLE
Thicken chart skeleton bars and stop them collapsing in a dashboard widget

### DIFF
--- a/moo-ds/src/css/components/_skeleton-chart.css
+++ b/moo-ds/src/css/components/_skeleton-chart.css
@@ -25,9 +25,9 @@
 .skeleton-chart-bar,
 .skeleton-chart-horizontal-bar {
     display: flex;
-    /* 2%, not 4%: with N bars there are N-1 gaps, so 4% spent most of an
-       eight-bar chart on whitespace and left the bars reading as hairlines
-       next to the real chart they stand in for. */
+    /* 2%, not 4%: with N bars there are N-1 gaps, so at 4% an eight-bar chart
+       spent 28% of its width on gaps and the bars read as thin next to the
+       real chart they stand in for. */
     gap: 2%;
 }
 

--- a/moo-ds/src/css/components/_skeleton-chart.css
+++ b/moo-ds/src/css/components/_skeleton-chart.css
@@ -25,7 +25,10 @@
 .skeleton-chart-bar,
 .skeleton-chart-horizontal-bar {
     display: flex;
-    gap: 4%;
+    /* 2%, not 4%: with N bars there are N-1 gaps, so 4% spent most of an
+       eight-bar chart on whitespace and left the bars reading as hairlines
+       next to the real chart they stand in for. */
+    gap: 2%;
 }
 
 .skeleton-chart-bar {
@@ -46,6 +49,10 @@
 .skeleton-chart-bar > .skeleton-chart-element {
     flex: 1 1 0;
 
+    /* NOTE: these percentages need the host to give .skeleton-chart a definite
+       height. Against an indefinite one they compute to 0, not auto, so the
+       bars vanish and align-self: stretch cannot rescue them (stretch only
+       applies when the cross size is auto). Sizing the host is the contract. */
     &:nth-child(8n + 1) { height: 62%; }
     &:nth-child(8n + 2) { height: 88%; }
     &:nth-child(8n + 3) { height: 45%; }

--- a/moo-ds/src/css/pages/_dashboard.css
+++ b/moo-ds/src/css/pages/_dashboard.css
@@ -86,6 +86,11 @@ main.dashboard {
         > .skeleton-chart {
             flex: 1;
             height: auto;
+            /* Restore the floor the `min-height: 0` above removes. With
+               height: auto, a variant whose children are flex-basis: 0 has
+               nothing to derive a height from if flex does not engage, and
+               collapses to zero. */
+            min-height: 12rem;
         }
     }
 }

--- a/moo-ds/src/css/pages/_dashboard.css
+++ b/moo-ds/src/css/pages/_dashboard.css
@@ -71,7 +71,10 @@ main.dashboard {
             align-self: start;
         }
 
-        > *:not(.section-header) {
+        /* .skeleton-chart is excluded so it keeps the min-height floor declared
+           with the component. Zeroing it here and restoring it below would make
+           the same value true in two places. */
+        > *:not(.section-header):not(.skeleton-chart) {
             flex: none;
             min-height: 0;
             overflow: hidden;
@@ -82,15 +85,11 @@ main.dashboard {
            the header's height -- clipping its own baseline axis against the
            section's overflow: hidden. Let it take the space that is actually
            left instead. Has to live here rather than in _skeleton-chart.css:
-           the rule above is both more specific and in a later import. */
+           only the dashboard knows the body has a header above it to share
+           with. */
         > .skeleton-chart {
             flex: 1;
             height: auto;
-            /* Restore the floor the `min-height: 0` above removes. With
-               height: auto, a variant whose children are flex-basis: 0 has
-               nothing to derive a height from if flex does not engage, and
-               collapses to zero. */
-            min-height: 12rem;
         }
     }
 }


### PR DESCRIPTION
Follow-up to #703, from two problems spotted in use.

## 1. Bars were too thin

`gap` was `4%`. With N bars there are N−1 gaps, so an eight-bar chart spent **28% of its width on whitespace** and the bars read as hairlines next to the real chart they stand in for.

Now `2%`. Measured in a 300px dashboard row:

| | Before | After |
| --- | --- | --- |
| Horizontal bar thickness (count 6) | 31px | **35px** |
| Horizontal bar thickness (count 2) | 112px | **115px** |

## 2. Collapse inside a dashboard widget

The rule added in #703 set `flex: 1; height: auto`, but the `.section > *:not(.section-header)` rule above it also sets `min-height: 0`. A variant whose children are `flex-basis: 0` — `horizontal-bar` — then has nothing to derive a height from if flex doesn't engage, and collapses to zero. Restored the 12rem floor.

## What this does *not* fix, deliberately

In a host with **no definite height at all**, the `bar` variant's percentage heights compute to `0` — not `auto` — so the bars vanish while the container still shows its 12rem floor.

I tried `align-self: stretch` as a graceful fallback and **measured that it does nothing**: stretch only applies when the cross size is `auto`, and a percentage against an indefinite containing block resolves to `0`, not `auto`. So I removed it again rather than leave dead code sitting under a confident comment. There's a `NOTE` in `_skeleton-chart.css` recording the mechanism.

Sizing the host stays the contract — it's what "fills its container" already implies, and every current usage does it. Making the component independent of it needs a per-bar wrapper using flex ratios instead of percentage heights, which is a bigger change than this should carry. Happy to do it separately if the silent-collapse failure mode bothers you.

## Verification

- All numbers above measured in the running dashboard, not estimated.
- One wrinkle worth flagging: my first round of measurements was **against stale CSS** — Vite hadn't hot-reloaded the stylesheet, and `gap` still read `4%`. I only caught it because I asserted on a value the change should have altered. Re-measured after a reload.
- 1808 tests, lint, build, type-check all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
