### PR TITLE
Size skeleton bars per slot, keep pie and doughnut circular

### DIFF
--- a/moo-ds/src/css/components/_skeleton-chart.css
+++ b/moo-ds/src/css/components/_skeleton-chart.css
@@ -22,14 +22,18 @@
 
 /* --- bar / horizontal-bar ------------------------------------------------- */
 
+/* No `gap`. A percentage gap is a share of the whole, so its effect swung with
+   the bar count: at 4% eight bars spent 28% of the width on gaps and read as
+   thin, while two bars had a single gap and became slabs. Chart.js instead
+   sizes a bar at categoryPercentage x barPercentage = 0.72 of its own slot
+   whatever the count, so the bars below scale within their slot to match. */
 .skeleton-chart-bar,
 .skeleton-chart-horizontal-bar {
     display: flex;
-    /* 2%, not 4%: with N bars there are N-1 gaps, so at 4% an eight-bar chart
-       spent 28% of its width on gaps and the bars read as thin next to the
-       real chart they stand in for. */
-    gap: 2%;
 }
+
+.skeleton-chart-bar > .skeleton-chart-element { transform: scaleX(0.72); }
+.skeleton-chart-horizontal-bar > .skeleton-chart-element { transform: scaleY(0.72); }
 
 .skeleton-chart-bar {
     flex-direction: row;
@@ -122,9 +126,19 @@
     --skeleton-chart-hole: 0;
     --slice-angle: calc(360deg / 6);
 
+    /* Stay circular. `aspect-ratio` alone was not enough: the base rule's
+       height: 100% made the height definite, so in a host narrower than it was
+       tall `max-width` clamped the width and the ratio could not rebalance --
+       a 150x400 host gave a 150x400 oval. Both axes auto with both maxes lets
+       the ratio fit whichever axis is smaller. `min-width` matches the
+       inherited min-height floor so a host below it overflows as a circle
+       rather than going oval. */
     width: auto;
+    height: auto;
     aspect-ratio: 1;
     max-width: 100%;
+    max-height: 100%;
+    min-width: 12rem;
     margin-inline: auto;
     border-radius: 50%;
 

--- a/moo-ds/src/css/pages/_dashboard.css
+++ b/moo-ds/src/css/pages/_dashboard.css
@@ -91,5 +91,13 @@ main.dashboard {
             flex: 1;
             height: auto;
         }
+
+        /* Round variants opt out: flex: 1 would make the height definite again
+           and a widget narrower than it is tall would clamp the width into an
+           oval. Sizing themselves from the smaller axis keeps them circular. */
+        > .skeleton-chart-pie,
+        > .skeleton-chart-doughnut {
+            flex: 0 1 auto;
+        }
     }
 }


### PR DESCRIPTION
Follow-up to #704. Two sizing problems, both from the same root cause: sizes were expressed as a share of the **whole chart** rather than of each element's own slot.

## 1. Bar thickness swung with the bar count

A percentage `gap` is a share of the whole, so its effect depended entirely on how many bars there were. At `4%`, eight bars spent **28% of the width on gaps** and read as thin; at `2%`, two bars had a single gap and became slabs. One knob could not satisfy both.

Chart.js doesn't work that way — it sizes a bar at `categoryPercentage × barPercentage = 0.72` of **its own slot**, whatever the count. So the gap is gone and each bar scales within its slot instead:

```css
.skeleton-chart-bar > .skeleton-chart-element { transform: scaleX(0.72); }
.skeleton-chart-horizontal-bar > .skeleton-chart-element { transform: scaleY(0.72); }
```

Measured at exactly **72% of slot** for 2, 6 and 8 bars — count-independent, matching the real chart it stands in for.

## 2. Pie and doughnut went oval

`aspect-ratio: 1` was already there but couldn't hold. The base rule's `height: 100%` made the height definite, so in a host narrower than it was tall `max-width: 100%` clamped the width with nothing able to rebalance the ratio. A 150×400 host produced a **150×400 oval**.

Both axes are now `auto` with both maxes, letting the ratio fit whichever axis is smaller, plus a `min-width` matching the inherited `min-height` floor so a host below the floor overflows *as a circle* rather than going oval.

Round variants also opt out of the dashboard's `flex: 1` — that would make the height definite again and reintroduce the oval in a widget narrower than it is tall.

## Verification

Measured across five host shapes plus a real dashboard widget:

| Host | Result |
| --- | --- |
| Wide (400×150) | circle |
| Tall (150×400) | circle |
| Square (250×250) | circle |
| Unsized (300 wide, auto height) | circle |
| Flex column (150×400) | circle |
| Real dashboard widget (751×300 section) | 168×168 circle, 81px inside the section |

Bars: 72% of slot at counts 2, 6 and 8.

1808 tests, lint, build, type-check all pass.

### A note on how this was checked

An earlier round of measurements in this work was taken against **stale CSS** — Vite hadn't hot-reloaded and `gap` still read its old value. Every number above was taken after confirming a changed property had actually reached the browser, and one intermediate result turned out to be a probe artefact (an injected element measured alongside the existing one rather than replacing it), which is why the section-overflow figure is re-measured with the probe as the sole child.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
