### PR TITLE
fix(moo-ds): separate a Row's lines when it wraps, on one shared --gap

### DIFF
--- a/moo-ds/src/css/_moo-grid.css
+++ b/moo-ds/src/css/_moo-grid.css
@@ -30,21 +30,22 @@
     max-width: min(3120px, max(540px, 100dvw - 80px));
 }
 
-/* One --gap for both axes: the space between columns and, when a row wraps, between its lines.
+/* One --gap for both axes, spent differently on each because only one of them can afford it.
 
-   It is spent as negative margin plus child padding rather than the `gap` property, which cannot
-   be used while .col-* are percentage widths: width: 50% resolves against the row, so two .col-6
-   already fill it exactly and any gap is pure overflow that wraps the second column onto its own
-   line (measured: 2x300px in a 600px row + 24px gap). Moving to the property means moving .row to
-   grid with `grid-column: span N`, which changes the public class contract.
+   Across (main axis) it is negative margin on the row plus padding on the children. `column-gap`
+   is unusable while .col-* are percentage widths: width: 50% resolves against the row, so two
+   .col-6 already fill it exactly and any main-axis gap is pure overflow that wraps the second
+   column onto its own line permanently (measured: 2x300px in a 600px row + 24px gap). Escaping
+   that means moving .row to grid with `grid-column: span N`, which changes the public contract.
 
-   Vertically it costs nothing on a single line: every child carries --gap as top margin and the
-   row cancels one gap's worth, so one line nets to zero and only wrapped lines are separated. */
+   Down (cross axis) `row-gap` is fine, and is what this uses: it spaces flex *lines* and has no
+   bearing on how wide a line's items may be, so the overflow above cannot arise. It also applies
+   only between lines, so a single-line row is untouched and an empty one occupies nothing. */
 .row {
     --gap: 1.5rem;
     display: flex;
     flex-wrap: wrap;
-    margin-block-start: calc(-1 * var(--gap));
+    row-gap: var(--gap);
     margin-inline: calc(-0.5 * var(--gap));
 }
 
@@ -53,7 +54,6 @@
     width: 100%;
     max-width: 100%;
     padding-inline: calc(var(--gap) * 0.5);
-    margin-block-start: var(--gap);
 }
 
 .col { flex: 1 0 0%; }

--- a/moo-ds/src/css/_moo-grid.css
+++ b/moo-ds/src/css/_moo-grid.css
@@ -2,7 +2,6 @@
 
 .container,
 .container-fluid {
-    --gap: 1.5rem;
     width: 100%;
     padding-inline: calc(var(--gap) * 0.5);
     margin-inline: auto;
@@ -30,7 +29,8 @@
     max-width: min(3120px, max(540px, 100dvw - 80px));
 }
 
-/* One --gap for both axes, spent differently on each because only one of them can afford it.
+/* --gap (see _variables.css) on both axes, spent differently on each because only one of them
+   can afford it.
 
    Across (main axis) it is negative margin on the row plus padding on the children. `column-gap`
    is unusable while .col-* are percentage widths: width: 50% resolves against the row, so two
@@ -42,7 +42,6 @@
    bearing on how wide a line's items may be, so the overflow above cannot arise. It also applies
    only between lines, so a single-line row is untouched and an empty one occupies nothing. */
 .row {
-    --gap: 1.5rem;
     display: flex;
     flex-wrap: wrap;
     row-gap: var(--gap);

--- a/moo-ds/src/css/_moo-grid.css
+++ b/moo-ds/src/css/_moo-grid.css
@@ -2,10 +2,9 @@
 
 .container,
 .container-fluid {
-    --gutter-x: 1.5rem;
-    --gutter-y: 0;
+    --gap: 1.5rem;
     width: 100%;
-    padding-inline: calc(var(--gutter-x) * 0.5);
+    padding-inline: calc(var(--gap) * 0.5);
     margin-inline: auto;
 }
 
@@ -31,27 +30,30 @@
     max-width: min(3120px, max(540px, 100dvw - 80px));
 }
 
-/* The gutter stays as negative margin plus child padding rather than becoming
-   `gap`. It cannot be `gap` while .col-* are percentage widths: width: 50%
-   resolves against the row, so two .col-6 already fill it exactly and any gap
-   is pure overflow that wraps the second column onto its own line (measured:
-   2x300px in a 600px row + 24px gap). Moving to `gap` means moving .row to
-   grid with `grid-column: span N`, which changes the public class contract. */
+/* One --gap for both axes: the space between columns and, when a row wraps, between its lines.
+
+   It is spent as negative margin plus child padding rather than the `gap` property, which cannot
+   be used while .col-* are percentage widths: width: 50% resolves against the row, so two .col-6
+   already fill it exactly and any gap is pure overflow that wraps the second column onto its own
+   line (measured: 2x300px in a 600px row + 24px gap). Moving to the property means moving .row to
+   grid with `grid-column: span N`, which changes the public class contract.
+
+   Vertically it costs nothing on a single line: every child carries --gap as top margin and the
+   row cancels one gap's worth, so one line nets to zero and only wrapped lines are separated. */
 .row {
-    --gutter-x: 1.5rem;
-    --gutter-y: 0;
+    --gap: 1.5rem;
     display: flex;
     flex-wrap: wrap;
-    margin-block-start: calc(-1 * var(--gutter-y));
-    margin-inline: calc(-0.5 * var(--gutter-x));
+    margin-block-start: calc(-1 * var(--gap));
+    margin-inline: calc(-0.5 * var(--gap));
 }
 
 .row > * {
     flex-shrink: 0;
     width: 100%;
     max-width: 100%;
-    padding-inline: calc(var(--gutter-x) * 0.5);
-    margin-block-start: var(--gutter-y);
+    padding-inline: calc(var(--gap) * 0.5);
+    margin-block-start: var(--gap);
 }
 
 .col { flex: 1 0 0%; }

--- a/moo-ds/src/css/_variables.css
+++ b/moo-ds/src/css/_variables.css
@@ -96,6 +96,13 @@
   --border-width: 1px;
   --border-radius: 0.375rem;
 
+  /* The space between laid-out things: between a Row's columns and its wrapped lines, and between
+     a Stack's children. One token so a row of cards and a stack of them are spaced alike.
+
+     It inherits, which is the useful part — set it on any container and everything laid out inside
+     retunes to it, no component needing a prop for the purpose. */
+  --gap: 1.5rem;
+
   /* Follow system preference by default */
   color-scheme: light dark;
   --primary: var(--default-primary);

--- a/moo-ds/src/css/components/_section-row.css
+++ b/moo-ds/src/css/components/_section-row.css
@@ -1,6 +1,5 @@
-.row.section-row {
-    /* Its vertical gutter used to be set here; .row carries --gap on both axes now. */
-    .section {
-        height: 100%;
-    }
+/* A row of Sections that should read as one band: equal heights, so their bottoms line up however
+   much each contains. Spacing is --gap, from .row, like any other row. */
+.row.section-row .section {
+    height: 100%;
 }

--- a/moo-ds/src/css/components/_section-row.css
+++ b/moo-ds/src/css/components/_section-row.css
@@ -1,6 +1,5 @@
 .row.section-row {
-    --gutter-y: 1.5rem;
-
+    /* Its vertical gutter used to be set here; .row carries --gap on both axes now. */
     .section {
         height: 100%;
     }

--- a/moo-ds/src/css/layout/_stack.css
+++ b/moo-ds/src/css/layout/_stack.css
@@ -1,5 +1,7 @@
+/* The same --gap a Row uses, so a stack of cards and a row of them are spaced alike. Nothing
+   stops the property here — a stack is one column, so there is no main axis to overflow. */
 .stack {
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
+    gap: var(--gap);
 }


### PR DESCRIPTION
## The bug

A `Row` whose columns wrap had its lines touching — no space between them at all. The vertical gutter existed as `--gutter-y`, but defaulted to `0` with nothing exposing it: no prop on `Row`, no utility class. There was no supported way to get the gap.

## What it took

**Only `column-gap` is unusable, not `gap` generally.** My first pass got this wrong and Copilot caught it. `.col-*` are percentage widths, so two `.col-6` fill the row exactly and any *main-axis* gap is overflow that wraps every column onto its own line permanently. `row-gap` spaces flex *lines* and has no bearing on how wide a line's items may be, so it is fine — and it is what the vertical axis uses now. That also removed a real edge case: the previous negative-margin approach applied whether or not the row had children, so an empty row pulled the content below it upward.

**`--gutter-x` / `--gutter-y` become one `--gap`.** That is what they already were: both places setting the vertical one independently set it to the horizontal value, turning on by hand what should have been on. The Bootstrap-derived naming goes with them.

**`--gap` is a token on `:root`, not a row-local.** `.stack` was hard-coding `gap: 1.5rem` — the same number, written twice, in the other component that exists to space things. `.row`, `.container` and `.stack` all read the token now, so a row of cards and a stack of them are spaced alike by construction. Being inherited, it also hands every layout a knob for free: set `--gap` on any container and everything laid out inside retunes, no component needing a prop for it.

## Measured in demoo

| | before | after |
|---|---|---|
| single-line row, offset from element above | 0px | **0px** |
| gap between columns on one line | 21px | **21px** |
| three `.col-4` on one line | 274/274/274 | **274/274/274** |
| gap between wrapped lines | **0px** | **21px** |
| Stack gap | 21px | **21px** |
| empty row height / pull-up | 0px / **-21px** | **0px / 0px** |
| wrapper at `--gap: 0.5rem` → Stack + Row | n/a | **7px / 7px** |

(21px is 1.5rem against the 14px root `_reset.css` sets.)

## Consumers

`--gutter-x` / `--gutter-y` are gone; `--gap` replaces both. Neither known override breaks — both set the value that is now the default:

- `_section-row.css` — removed here, leaving the equal-height rule it exists for
- MooBank `App.css` `.section-row { --gutter-y: 1.5rem }` — deletable once this publishes

I opted against aliasing the old names (raised in review): the rename was the point, an alias keeps the old spelling alive, and neither override changes anything visually by disappearing. Easy to add back if that's the wrong call.

## Verification

- 1811 tests pass
- moo-ds builds; lint 0 errors
- Layout measured in a live browser, per the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)
