### PR TITLE
Let pie and doughnut skeletons fill their widget

### DIFF
--- a/moo-ds/src/css/pages/_dashboard.css
+++ b/moo-ds/src/css/pages/_dashboard.css
@@ -92,12 +92,19 @@ main.dashboard {
             height: auto;
         }
 
-        /* Round variants opt out: flex: 1 would make the height definite again
-           and a widget narrower than it is tall would clamp the width into an
-           oval. Sizing themselves from the smaller axis keeps them circular. */
+        /* Round variants take the height like everything else, but cap it by the
+           widget's own width so one taller than it is wide shrinks the disc
+           rather than stretching it into an oval. The grid cell is an
+           inline-size container, so 100cqw is that width; less the section's
+           padding and border (15 + 15 + 1 + 1).
+
+           Opting them out of flex instead -- the previous attempt -- kept them
+           circular but stranded them at their min-width floor: 168px of disc in
+           a 621px-tall widget. */
         > .skeleton-chart-pie,
         > .skeleton-chart-doughnut {
-            flex: 0 1 auto;
+            flex: 1;
+            max-height: calc(100cqw - 32px);
         }
     }
 }


### PR DESCRIPTION
Follow-up to #705, which overcorrected.

## What was wrong

#705 kept the round variants circular by opting them out of the dashboard's `flex: 1`, on the reasoning that a definite height would let a narrow widget clamp the width into an oval. That reasoning held — but the cure was worse. Without flex the disc had nothing to size against and fell back to its `min-width` floor: **a 168px disc in a 621px-tall widget**, filling 30% of the space with the rest blank.

## Fix

They take the height like every other variant, with the height capped by the widget's **own width** so a widget taller than it is wide shrinks the disc rather than stretching it:

```css
> .skeleton-chart-pie,
> .skeleton-chart-doughnut {
    flex: 1;
    max-height: calc(100cqw - 32px);
}
```

The dashboard grid cell is already `container-type: inline-size`, so `100cqw` is that cell's width; the `32px` is the section's own padding and border (15 + 15 + 1 + 1). That gives `min(available width, available height)` — which plain CSS can't express across axes, and is the thing that was missing.

## Verification

Measured in real grid cells of three shapes, so `cqw` resolves against a genuine container rather than a synthetic one:

| Widget | Disc | Fill of smaller axis |
| --- | --- | --- |
| 751×300 single | 234px circle | 98% |
| 751×621 double | 555px circle | 99% |
| 260×621 double | 228px circle | 100% — capped by width, not stretched |

The narrow-tall case is the one #705 was protecting against, and it stays circular here while the other two now actually fill.

Confirmed the computed `max-height` differs per cell (718.891px vs 228px), proving the container query resolves per widget rather than being a constant.

1811 tests, lint, build, type-check all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
