### PR TITLE
Never substitute a spinner for a supplied loadingPlaceholder

### DIFF
--- a/moo-ds/README.md
+++ b/moo-ds/README.md
@@ -40,7 +40,16 @@ For a widget that fetches, that ladder runs: nothing under ~300ms → `Skeleton`
 </Widget>
 ```
 
-Omit `loadingPlaceholder` — or let it fall through to a falsy value — and you get the default spinner back.
+Omitting `loadingPlaceholder` gives the spinner. Supplying one means it is *always* used: a value that evaluates to `false` renders nothing rather than reverting to a spinner. The point of a skeleton is to replace the spinner, not to replace it sometimes — a widget whose loading style changes with state the caller wasn't thinking about is worse than either choice made consistently.
+
+That matters most when `loading` is broader than the placeholder's own condition. This shows a skeleton on first load and a *spinner* on every refetch, which is almost certainly not what was meant:
+
+```tsx
+loading={isLoading || isFetching}
+loadingPlaceholder={isLoading && <Skeleton.Chart variant="bar" />}   // don't
+```
+
+Keep the placeholder unconditional — it is only consulted while `loading` — and use `refreshing` for refetches.
 
 The skeleton shimmer is a single moving gradient that resolves its colours from the active theme and collapses to a static placeholder under `prefers-reduced-motion`. Skeleton shapes are decorative (`aria-hidden`); the loading *region* that contains them carries `aria-busy`. `ProgressIndeterminate` is a `role="progressbar"` with `aria-busy` and no `aria-valuenow`; under `prefers-reduced-motion` it renders as a static full-width bar. The comet spinner slows to 2s rather than stopping — a stopped spinner reads as a hang.
 

--- a/moo-ds/src/components/Widget.tsx
+++ b/moo-ds/src/components/Widget.tsx
@@ -37,14 +37,14 @@ export interface WidgetProps {
     /** No data yet — the body is replaced by `loadingPlaceholder`. Wins over `refreshing`. */
     loading?: boolean;
     /**
-     * What to show while `loading`. Omit it for a centred `SpinnerContainer`.
+     * What to show while `loading`. Omit it (or pass `null`/`undefined`) for a centred `SpinnerContainer`.
      *
      * Supply one where a spinner would throw away shape you already know —
      * `loadingPlaceholder={<Skeleton.Chart variant="bar" />}` for a chart.
      *
      * Once supplied it is always used: a value that evaluates to `false` renders
      * nothing rather than reverting to the spinner, so the loading style cannot
-     * change underneath you. Only omitting the prop gives the spinner.
+     * change underneath you. Only `undefined`/`null` (including omitting the prop) gives the spinner.
      */
     loadingPlaceholder?: React.ReactNode;
     /** Data is on screen and being refetched: edge bar + dimmed body, body stays mounted. */

--- a/moo-ds/src/components/Widget.tsx
+++ b/moo-ds/src/components/Widget.tsx
@@ -17,9 +17,12 @@ export const Widget: React.FC<PropsWithChildren<WidgetProps>> = ({ children, loa
             aria-busy={loading || undefined}
             {...rest}
         >
-            {/* Truthiness rather than a null check, so `cond && <Thing />` falling
-                through to false still gets the default rather than nothing. */}
-            {loading && (loadingPlaceholder || <SpinnerContainer />)}
+            {/* ?? not ||: only an absent prop falls back to the spinner. A widget
+                that has been given a placeholder must never substitute one, or the
+                loading style silently changes with state the caller wasn't thinking
+                about — the point of a skeleton is to replace the spinner, not to
+                replace it sometimes. */}
+            {loading && (loadingPlaceholder ?? <SpinnerContainer />)}
             {/* "Refreshing", not the default "Loading": the data is already on
                 screen, and announcing a load implies it is not. */}
             {!loading && refreshing && <ProgressIndeterminate variant="edge" aria-label="Refreshing" />}
@@ -34,10 +37,14 @@ export interface WidgetProps {
     /** No data yet — the body is replaced by `loadingPlaceholder`. Wins over `refreshing`. */
     loading?: boolean;
     /**
-     * What to show while `loading`. Defaults to a centred `SpinnerContainer`.
+     * What to show while `loading`. Omit it for a centred `SpinnerContainer`.
      *
      * Supply one where a spinner would throw away shape you already know —
      * `loadingPlaceholder={<Skeleton.Chart variant="bar" />}` for a chart.
+     *
+     * Once supplied it is always used: a value that evaluates to `false` renders
+     * nothing rather than reverting to the spinner, so the loading style cannot
+     * change underneath you. Only omitting the prop gives the spinner.
      */
     loadingPlaceholder?: React.ReactNode;
     /** Data is on screen and being refetched: edge bar + dimmed body, body stays mounted. */

--- a/moo-ds/src/components/__tests__/Widget.test.tsx
+++ b/moo-ds/src/components/__tests__/Widget.test.tsx
@@ -86,14 +86,26 @@ describe('Widget', () => {
       expect(screen.queryByTestId('custom')).not.toBeInTheDocument();
     });
 
-    // `cond && <Thing />` falls through to false when cond is false, and that
-    // should still give the default rather than an empty widget.
-    it.each([null, undefined, false, ''] as const)('falls back to the spinner for %p', (value) => {
+    // Only an absent prop means "no placeholder chosen". null and undefined
+    // read as absent; anything else the caller passed is honoured as-is.
+    it.each([null, undefined] as const)('falls back to the spinner for %p', (value) => {
       const { container } = render(
         <Widget size="single" loading loadingPlaceholder={value}>Content</Widget>
       );
 
       expect(container.querySelector('.spinner-container')).toBeInTheDocument();
+    });
+
+    // The point of a skeleton is to replace the spinner, not to replace it
+    // sometimes. `cond && <Thing />` going false must not resurrect the spinner
+    // — the loading style cannot change with state the caller didn't consider.
+    it.each([false, ''] as const)('renders nothing rather than the spinner for %p', (value) => {
+      const { container } = render(
+        <Widget size="single" loading loadingPlaceholder={value}>Content</Widget>
+      );
+
+      expect(container.querySelector('.spinner-container')).not.toBeInTheDocument();
+      expect(screen.queryByText('Content')).not.toBeInTheDocument();
     });
 
     it('defaults to the spinner when omitted', () => {


### PR DESCRIPTION
Reported from the field: "I'm seeing the skeletons then often seeing a spinner briefly."

## Cause

```tsx
{loading && (loadingPlaceholder || <SpinnerContainer />)}
```

A placeholder that evaluates to `false` silently reverted to a spinner. I chose truthiness in #703 to stop `cond && <Thing />` blanking the widget, and flagged it there as a judgement call. It was the wrong trade: it makes the widget's **loading style change with state the caller wasn't thinking about**.

The shape that triggers it is a `loading` broader than the placeholder's own condition:

```tsx
loading={isLoading || isFetching}                        // true on first load AND refetch
loadingPlaceholder={isLoading && <Skeleton.Chart />}     // truthy only on first load
```

First load → skeleton. Every refetch → `loading` still true, placeholder now `false` → **spinner**. Which is exactly the reported symptom, and the spinner appearing *briefly* fits too: `Spinner` has `delay = 300`, so it only paints if the fallback stays mounted past 300ms.

## Fix

`??` instead of `||`. Only an absent prop falls back:

| `loadingPlaceholder` | Renders |
| --- | --- |
| omitted / `undefined` / `null` | `SpinnerContainer` |
| any node | that node |
| `false`, `""` | nothing |

Supply a placeholder and it is *always* used. A blank body is at least honest about which affordance was chosen; a surprise spinner is not.

## Why this way round

The point of a skeleton is to replace the spinner, not to replace it sometimes. A component that honours your placeholder most of the time is worse than either option applied consistently — it turns a styling decision into a state-dependent one, and the failure is invisible until someone happens to watch a refetch.

The README gains the anti-pattern above, because the fix removes the *symptom* without removing the mistake that causes it — folding `isFetching` into `loading` should be `refreshing` instead:

```tsx
loading={isPending}
loadingPlaceholder={<Skeleton.Chart variant="bar" count={10} />}
refreshing={!isPending && isFetching}
```

## Behaviour change

Anyone relying on a falsy placeholder to produce a spinner now gets an empty body. That was undocumented and almost certainly unintended wherever it happened — it's the bug being fixed.

Tests updated: `null`/`undefined` still assert the spinner; `false`/`""` now assert no spinner *and* no children. 1811 tests, lint, build, type-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
